### PR TITLE
LP: スマホDLボタン修正 + 多言語対応 (en/zh/fr/it/es/th)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -75,20 +75,31 @@ ul, ol { margin: 0 0 1em; padding-left: 1.4em; }
   -webkit-backdrop-filter: saturate(160%) blur(10px);
   border-bottom: 1px solid var(--c-border);
 }
-.site-header__inner { display: flex; align-items: center; justify-content: space-between; height: 64px; }
-.site-header__brand { display: inline-flex; align-items: center; gap: 8px; font-family: var(--font-heading); font-weight: 800; font-size: 1.1rem; color: var(--c-text); }
-.site-header__brand-mark { width: 32px; height: 32px; border-radius: 50%; background: var(--c-primary); display: inline-flex; align-items: center; justify-content: center; font-size: 1.05rem; }
+.site-header__inner { display: flex; align-items: center; gap: 10px; height: 64px; }
+.site-header__brand { display: inline-flex; align-items: center; gap: 8px; font-family: var(--font-heading); font-weight: 800; font-size: 1.05rem; color: var(--c-text); white-space: nowrap; flex-shrink: 0; }
+.site-header__brand-mark { width: 30px; height: 30px; border-radius: 50%; background: var(--c-primary); display: inline-flex; align-items: center; justify-content: center; font-size: 1rem; flex-shrink: 0; }
 .site-nav { display: none; align-items: center; gap: 28px; }
 .site-nav a { color: var(--c-text-sub); font-weight: 600; font-size: 0.92rem; transition: color 0.18s; }
 .site-nav a:hover { color: var(--c-text); }
-.site-header__cta { display: none; }
-.menu-btn { width: 40px; height: 40px; display: inline-flex; align-items: center; justify-content: center; border-radius: 8px; }
+
+/* Header download CTA: compact icon pill on mobile, full label from 768px up.
+   Icon-only on mobile keeps the header from overflowing in any language. */
+.site-header__cta { display: inline-flex; flex-shrink: 0; margin-left: auto; }
+.site-header .site-header__cta { padding: 0; width: 40px; height: 40px; border-radius: 12px; box-shadow: 0 3px 0 var(--c-primary-dark); }
+.site-header__cta-icon { width: 20px; height: 20px; flex-shrink: 0; }
+.site-header__cta-label { display: none; white-space: nowrap; }
+
+.menu-btn { width: 40px; height: 40px; display: inline-flex; align-items: center; justify-content: center; border-radius: 8px; flex-shrink: 0; }
 .menu-btn:hover { background: var(--c-surface); }
 .menu-btn svg { width: 22px; height: 22px; }
 @media (min-width: 768px) {
+  .site-header__inner { justify-content: space-between; }
   .site-nav { display: flex; }
   .menu-btn { display: none; }
-  .site-header__cta { display: inline-flex; }
+  .site-header__cta { margin-left: 0; }
+  .site-header .site-header__cta { padding: 14px 28px; width: auto; height: auto; border-radius: var(--radius); box-shadow: 0 4px 0 var(--c-primary-dark); }
+  .site-header__cta-icon { display: none; }
+  .site-header__cta-label { display: inline; }
 }
 
 /* Mobile drawer */
@@ -344,6 +355,28 @@ ul, ol { margin: 0 0 1em; padding-left: 1.4em; }
 }
 .site-footer__social a:hover { background: var(--c-primary); color: var(--c-text); }
 .site-footer__social svg { width: 18px; height: 18px; }
+
+/* Language switcher (footer) */
+.lang-switch {
+  display: flex; flex-wrap: wrap; gap: 8px 16px; align-items: center;
+  border-top: 1px solid #2C3338;
+  padding-top: 24px; margin-bottom: 24px;
+}
+.lang-switch__label { color: #8C949A; font-size: 0.8rem; font-weight: 700; margin-right: 4px; }
+.lang-switch a { color: #8C949A; font-size: 0.86rem; font-weight: 600; transition: color 0.18s; }
+.lang-switch a:hover { color: #fff; }
+.lang-switch a.is-current { color: #fff; text-decoration: underline; text-underline-offset: 3px; }
+
+/* Language switcher (mobile drawer) */
+#mobile-menu .mobile-menu__lang {
+  display: flex; flex-wrap: wrap; gap: 8px 14px;
+  padding: 14px 24px 6px; margin-top: 6px;
+  border-top: 1px solid var(--c-border);
+}
+#mobile-menu .mobile-menu__lang a {
+  display: inline; padding: 0; font-size: 0.92rem; font-weight: 600; color: var(--c-text-sub);
+}
+#mobile-menu .mobile-menu__lang a.is-current { color: var(--c-text); text-decoration: underline; text-underline-offset: 3px; }
 
 /* ----- 16. Sub-page primitives ----- */
 .page-header {

--- a/en/index.html
+++ b/en/index.html
@@ -1,0 +1,450 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>Explores｜The walking game that turns strolls into adventures</title>
+    <meta name="description" content="Explores is the walking game that turns an ordinary stroll into an adventure. Use a photo as your only clue and walk to a place you've never been. About 15 minutes per round. Free, with no in-app purchases." />
+    <meta name="author" content="Prokonjo" />
+    <meta name="theme-color" content="#FACD00" />
+    <link rel="canonical" href="https://prokonjo.com/en/" />
+
+    <!-- hreflang alternates -->
+    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/" />
+    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/" />
+    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/" />
+    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/" />
+    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/" />
+    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/" />
+    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/" />
+    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/" />
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Explores" />
+    <meta property="og:title" content="Explores｜The walking game that turns strolls into adventures" />
+    <meta property="og:description" content="A walking game where a single photo is your clue to reach a place you've never been. About 15 minutes per round. Free, with no in-app purchases." />
+    <meta property="og:url" content="https://prokonjo.com/en/" />
+    <meta property="og:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+    <meta property="og:image:type" content="image/jpeg" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:locale" content="en_US" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Explores｜The walking game that turns strolls into adventures" />
+    <meta name="twitter:description" content="A walking game where a single photo is your clue to reach a place you've never been. About 15 minutes per round. Free, with no in-app purchases." />
+    <meta name="twitter:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" href="/assets/favicon.png" />
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+
+    <link rel="stylesheet" href="/css/styles.css" />
+
+    <!-- Structured data -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "MobileApplication",
+        "name": "Explores",
+        "description": "The walking game that turns a stroll into an adventure. Use a photo as your clue to reach a place you've never been — an exploration experience that takes about 15 minutes per round.",
+        "url": "https://prokonjo.com/",
+        "applicationCategory": "GameApplication",
+        "operatingSystem": "iOS",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "JPY"
+        },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Prokonjo",
+          "url": "https://prokonjo.com/"
+        }
+      }
+    </script>
+
+    <!-- Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-P3YYZEG46Z');
+    </script>
+  </head>
+  <body>
+    <!-- ==================== Header ==================== -->
+    <header class="site-header">
+      <div class="container site-header__inner">
+        <a class="site-header__brand" href="#top" aria-label="Explores home">
+          <span class="site-header__brand-mark" aria-hidden="true">🧭</span>
+          <span>Explores</span>
+        </a>
+        <nav class="site-nav" aria-label="Main menu">
+          <a href="#about">Features</a>
+          <a href="#how">How to play</a>
+          <a href="#awards">Awards</a>
+          <a href="#faq">FAQ</a>
+          <a href="#contact">Contact</a>
+        </nav>
+        <a class="btn site-header__cta" href="#download" aria-label="Download">
+          <svg class="site-header__cta-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>
+          <span class="site-header__cta-label">Download</span>
+        </a>
+        <button class="menu-btn" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+        </button>
+      </div>
+      <div id="mobile-menu" data-open="false">
+        <a href="#about">Features</a>
+        <a href="#how">How to play</a>
+        <a href="#awards">Awards</a>
+        <a href="#faq">FAQ</a>
+        <a href="#contact">Contact</a>
+        <a href="/en/privacy-policy/">Privacy Policy</a>
+        <div class="mobile-menu__lang" aria-label="Language / Language">
+          <a href="/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/" hreflang="en" lang="en" class="is-current" aria-current="true">English</a>
+          <a href="/zh/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/" hreflang="es" lang="es">Español</a>
+          <a href="/th/" hreflang="th" lang="th">ไทย</a>
+        </div>
+      </div>
+    </header>
+
+    <!-- ==================== Hero ==================== -->
+    <section class="hero" id="top">
+      <div class="container hero__inner">
+        <div>
+          <span class="hero__eyebrow">🧭 City-walking exploration game</span>
+          <h1 class="hero__title">Turn your walk into an <em>adventure</em>.</h1>
+          <p class="hero__sub">
+            With just a photo as your clue, set off on foot for a place you've never been.<br />
+            About 15 minutes a round. A walking game that's free, with no in-app purchases.
+          </p>
+          <div class="hero__cta">
+            <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="Download on the App Store">
+              <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
+            </a>
+            <a class="btn btn--secondary" href="/en/tester-android">Android (testers wanted)</a>
+          </div>
+          <p class="hero__note">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>
+            Free ／ No in-app purchases ／ No ads
+          </p>
+        </div>
+        <div class="hero__visual">
+          <img src="/assets/img/game-desc.jpg" alt="A look at Explores gameplay" width="1200" height="676" />
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Empathy ==================== -->
+    <section class="section section--alt" id="about">
+      <div class="container">
+        <h2 class="section__title">Tired of the same old walk?</h2>
+        <p class="section__lead">You set out to walk for exercise, but the same route every day gets old fast.<br />Give your walk a purpose, and maybe — just maybe — it'll stick.</p>
+        <div class="card-grid">
+          <div class="empathy-card">
+            <div class="empathy-card__icon" aria-hidden="true">🛣️</div>
+            <h3>The same road, every day</h3>
+            <p>Home to the station and back. Before you know it, you're walking without even looking up.</p>
+          </div>
+          <div class="empathy-card">
+            <div class="empathy-card__icon" aria-hidden="true">📉</div>
+            <h3>It never becomes a habit</h3>
+            <p>You promise yourself you'll walk more, and three days later it's slipped your mind.</p>
+          </div>
+          <div class="empathy-card">
+            <div class="empathy-card__icon" aria-hidden="true">🤔</div>
+            <h3>No reason to walk</h3>
+            <p>When it's just for exercise, the motivation just won't last.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Value ==================== -->
+    <section class="section">
+      <div class="container">
+        <h2 class="section__title">With Explores,<br />a walk becomes an adventure.</h2>
+        <p class="section__lead">One photo is all the clue you get to reach somewhere new.<br />A different goal every time. Done in 15 minutes. Here's your reason to walk.</p>
+        <div class="card-grid">
+          <div class="value-card">
+            <div class="value-card__badge">01</div>
+            <h3>A new goal every time</h3>
+            <p>Pick how long you've got, and a destination is set at random each round. You'll never get bored of the same old spot.</p>
+          </div>
+          <div class="value-card">
+            <div class="value-card__badge">02</div>
+            <h3>Photo clues, real adventure</h3>
+            <p>No map — just a photo from near the destination to guide you. "Wait, haven't I seen that building somewhere…?" — and the adventure begins.</p>
+          </div>
+          <div class="value-card">
+            <div class="value-card__badge">03</div>
+            <h3>Done in 15 minutes</h3>
+            <p>On the way home from work, on a break, or out for a weekend stroll. Start when you feel like it, stop when you're ready — that easy.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== How ==================== -->
+    <section class="section section--surface" id="how">
+      <div class="container">
+        <h2 class="section__title">Three steps to play</h2>
+        <p class="section__lead">From opening the app to hitting the street: 30 seconds.</p>
+        <div class="steps">
+          <div class="step">
+            <div class="step__num">1</div>
+            <img class="step__img" src="/assets/img/game-play0.png" alt="Time selection screen" loading="lazy" />
+            <h3>Pick your time</h3>
+            <p>Choose how long you want to walk. "15 minutes," "30 minutes" — whatever suits your mood.</p>
+          </div>
+          <div class="step">
+            <div class="step__num">2</div>
+            <img class="step__img" src="/assets/img/game-play1.png" alt="Screen for reviewing the photo and map near the destination" loading="lazy" />
+            <h3>Memorize the destination</h3>
+            <p>Study the photo and map around your destination carefully before you start. Once the round begins, they're hidden.</p>
+          </div>
+          <div class="step">
+            <div class="step__num">3</div>
+            <img class="step__img" src="/assets/img/game-play2.png" alt="In-game screen while exploring" loading="lazy" />
+            <h3>Walk from memory</h3>
+            <p>With only the remaining time and distance to guide you, walk to your destination. "There — that's the view from the photo!"</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Video ==================== -->
+    <section class="section">
+      <div class="container">
+        <h2 class="section__title">Explores in action</h2>
+        <p class="section__lead">Take a look at real gameplay and a walk out on the streets.</p>
+        <div class="video-wrap">
+          <iframe src="https://www.youtube.com/embed/ldIJdk3zwHY?si=jwntDJV8pnRAHKio" title="Explores gameplay walkthrough video" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Awards ==================== -->
+    <section class="section section--alt" id="awards">
+      <div class="container">
+        <h2 class="section__title">Awards</h2>
+        <p class="section__lead">A track record of contest wins built up since our student days.</p>
+        <div class="awards">
+          <article class="award">
+            <img src="/assets/img/award-gikuhaku.jpg" alt="Geek Expo — Sponsor Award winner" loading="lazy" />
+            <div class="award__body">
+              <span class="award__tag">Sponsor Award</span>
+              <h3>Geek Expo</h3>
+              <p>At Geek Expo, hosted by Supporterz, Explores took home a Sponsor Award.</p>
+              <a class="award__link" href="https://x.com/geek_pjt/status/1789225529109057540" target="_blank" rel="noopener noreferrer">See the announcement post →</a>
+            </div>
+          </article>
+          <article class="award">
+            <img src="/assets/img/award-wakayama.jpg" alt="Wakayama Innovation Programming Contest — Grand Prize winner" loading="lazy" />
+            <div class="award__body">
+              <span class="award__tag">Grand Prize</span>
+              <h3>Wakayama Innovation Programming Contest</h3>
+              <p>Grand Prize for a smartphone app concept that tackles real challenges facing Wakayama.</p>
+              <a class="award__link" href="https://wakayama-innovation-lab.relic.co.jp/" target="_blank" rel="noopener noreferrer">See the organizer →</a>
+            </div>
+          </article>
+          <article class="award">
+            <img src="/assets/img/award-iizuka.jpg" alt="e-ZUKA Smart App Contest 2023 — Mayor's Award winner" loading="lazy" />
+            <div class="award__body">
+              <span class="award__tag">Mayor's Award + Sponsor Award</span>
+              <h3>e-ZUKA Smart App Contest 2023</h3>
+              <p>A double win at this contest hosted by Iizuka City, Fukuoka — the Iizuka Mayor's Award and a Sponsor Award.</p>
+              <a class="award__link" href="http://e-zuka.info/2023/resurt.html" target="_blank" rel="noopener noreferrer">See the results →</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Members ==================== -->
+    <section class="section" id="members">
+      <div class="container">
+        <h2 class="section__title">The development team</h2>
+        <p class="section__lead">A team of four, seriously building a way to "turn walks into adventures."</p>
+        <div class="members">
+          <div class="member">
+            <img src="/assets/img/member-akamatsu.png" alt="Taiki Akamatsu" loading="lazy" width="96" height="96" />
+            <h3>Taiki Akamatsu</h3>
+            <p>Founder / Engineer</p>
+            <div class="member__links">
+              <a href="https://www.wantedly.com/id/akamatsu_taiki" target="_blank" rel="noopener noreferrer" aria-label="Wantedly profile">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3a14 14 0 010 18M12 3a14 14 0 000 18"/></svg>
+              </a>
+              <a href="https://github.com/Taiki-sub" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+              </a>
+            </div>
+          </div>
+          <div class="member">
+            <img src="/assets/img/member-chang.png" alt="Juyoung Chang" loading="lazy" width="96" height="96" />
+            <h3>Juyoung Chang</h3>
+            <p>Designer</p>
+          </div>
+          <div class="member">
+            <img src="/assets/img/siteTop4.jpg" alt="Kento Kusumoto" loading="lazy" width="96" height="96" />
+            <h3>Kento Kusumoto</h3>
+            <p>Designer</p>
+          </div>
+          <div class="member">
+            <img src="/assets/img/member-hayashi.png" alt="Shinichiro Hayashi" loading="lazy" width="96" height="96" />
+            <h3>Shinichiro Hayashi</h3>
+            <p>Engineer</p>
+            <div class="member__links">
+              <a href="https://www.github.com/hashin2425" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== FAQ ==================== -->
+    <section class="section section--surface" id="faq">
+      <div class="container">
+        <h2 class="section__title">Frequently asked questions</h2>
+        <p class="section__lead">We've gathered the things you might be wondering before you play.</p>
+        <div class="faq">
+          <details>
+            <summary>Is it really free? Are there any in-app purchases?</summary>
+            <p>It's completely free. There are no in-app purchases of any kind — no gacha, no subscriptions. And for now, we're not showing ads either.</p>
+          </details>
+          <details>
+            <summary>How long does one round take?</summary>
+            <p>You can choose from options like 15, 20, or 30 minutes to match your mood. It works just as well for a quick break as for a weekend when you want to really put in the miles.</p>
+          </details>
+          <details>
+            <summary>Where can I play?</summary>
+            <p>Pretty much anywhere in town. Based on your GPS location, the game automatically generates goals within walking distance of where you are.</p>
+          </details>
+          <details>
+            <summary>How much data and battery does it use?</summary>
+            <p>Because it tracks your location continuously, longer sessions will drain your battery faster. Data use is mostly for displaying the map and isn't excessive.</p>
+          </details>
+          <details>
+            <summary>Any safety tips for playing?</summary>
+            <p>Please take great care not to use your phone while walking. Stop before crosswalks, avoid dark or deserted areas, and always follow the basic safety rules of any walk.</p>
+          </details>
+          <details>
+            <summary>Is there an Android version?</summary>
+            <p>We're currently looking for testers ahead of our Google Play release. You can sign up to be a tester on <a href="/en/tester-android">this page</a>.</p>
+          </details>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Final CTA ==================== -->
+    <section class="section cta-section" id="download">
+      <div class="container container--narrow">
+        <h2>Come on — let's turn your walk into an adventure.</h2>
+        <p>Download it now and take your first step toward somewhere you've never been.</p>
+        <div class="hero__cta" style="justify-content: center;">
+          <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="Download on the App Store">
+            <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
+          </a>
+          <a class="btn" href="/en/tester-android" style="background:#fff;">Android (testers wanted)</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Contact ==================== -->
+    <section class="section" id="contact">
+      <div class="container">
+        <h2 class="section__title">Contact</h2>
+        <p class="section__lead">Bug reports, feedback, collaboration ideas — reach out anytime.</p>
+        <div class="contact-card">
+          <p>Get in touch by email using the button below.</p>
+          <a class="btn btn--lg" href="mailto:akmatsutaiki@gmail.com?subject=%E3%80%90%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%A9%E3%83%BC%E3%82%BA%E3%80%91%E3%81%8A%E5%95%8F%E3%81%84%E5%90%88%E3%82%8F%E3%81%9B">
+            Contact us by email
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Footer ==================== -->
+    <footer class="site-footer">
+      <div class="container">
+        <div class="site-footer__grid">
+          <div>
+            <div class="site-footer__brand">Explores</div>
+            <p class="site-footer__brand-line">The walking game that turns strolls into adventures.<br />by Prokonjo</p>
+          </div>
+          <div class="site-footer__col">
+            <h4>Site</h4>
+            <ul>
+              <li><a href="#about">Features</a></li>
+              <li><a href="#how">How to play</a></li>
+              <li><a href="#awards">Awards</a></li>
+              <li><a href="#faq">FAQ</a></li>
+            </ul>
+          </div>
+          <div class="site-footer__col">
+            <h4>About us</h4>
+            <ul>
+              <li><a href="/en/privacy-policy/">Privacy Policy</a></li>
+              <li><a href="#contact">Contact</a></li>
+              <li><a href="/en/tester-android">Android testers</a></li>
+            </ul>
+          </div>
+        </div>
+        <nav class="lang-switch" aria-label="Language / Language">
+          <span class="lang-switch__label">Language</span>
+          <a href="/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/" hreflang="en" lang="en" class="is-current" aria-current="true">English</a>
+          <a href="/zh/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/" hreflang="es" lang="es">Español</a>
+          <a href="/th/" hreflang="th" lang="th">ไทย</a>
+        </nav>
+        <div class="site-footer__bottom">
+          <span>© 2024-2026 Prokonjo. All rights reserved.</span>
+          <div class="site-footer__social">
+            <a href="https://github.com/prokonjo-team" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+              <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      // Mobile menu toggle
+      (function() {
+        var btn = document.querySelector('.menu-btn');
+        var menu = document.getElementById('mobile-menu');
+        if (!btn || !menu) return;
+        btn.addEventListener('click', function() {
+          var open = menu.dataset.open === 'true';
+          menu.dataset.open = open ? 'false' : 'true';
+          btn.setAttribute('aria-expanded', String(!open));
+        });
+        // Close on link tap
+        menu.querySelectorAll('a').forEach(function(a) {
+          a.addEventListener('click', function() {
+            menu.dataset.open = 'false';
+            btn.setAttribute('aria-expanded', 'false');
+          });
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/en/privacy-policy/index.html
+++ b/en/privacy-policy/index.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>Privacy Policy｜Explores</title>
+    <meta name="description" content="The Explores privacy policy. How we handle location data and our data retention periods." />
+    <meta name="theme-color" content="#FACD00" />
+    <meta name="robots" content="noindex" />
+    <link rel="canonical" href="https://prokonjo.com/en/privacy-policy/" />
+    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/privacy-policy/" />
+    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/privacy-policy/" />
+    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/privacy-policy/" />
+    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/privacy-policy/" />
+    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/privacy-policy/" />
+    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/privacy-policy/" />
+    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/privacy-policy/" />
+    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/privacy-policy/" />
+    <link rel="icon" type="image/png" href="/assets/favicon.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/css/styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-P3YYZEG46Z');
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container site-header__inner">
+        <a class="site-header__brand" href="/en/" aria-label="Explores home">
+          <span class="site-header__brand-mark" aria-hidden="true">🧭</span>
+          <span>Explores</span>
+        </a>
+        <nav class="site-nav" aria-label="Main menu">
+          <a href="/en/#about">Features</a>
+          <a href="/en/#how">How to Play</a>
+          <a href="/en/#awards">Achievements</a>
+          <a href="/en/#faq">FAQ</a>
+          <a href="/en/#contact">Contact</a>
+        </nav>
+        <a class="btn site-header__cta" href="/en/#download" aria-label="Download">
+          <svg class="site-header__cta-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>
+          <span class="site-header__cta-label">Download</span>
+        </a>
+        <button class="menu-btn" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+        </button>
+      </div>
+      <div id="mobile-menu" data-open="false">
+        <a href="/en/#about">Features</a>
+        <a href="/en/#how">How to Play</a>
+        <a href="/en/#awards">Achievements</a>
+        <a href="/en/#faq">FAQ</a>
+        <a href="/en/#contact">Contact</a>
+        <a href="/en/privacy-policy/">Privacy Policy</a>
+        <div class="mobile-menu__lang" aria-label="Language / Language">
+          <a href="/privacy-policy/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/privacy-policy/" hreflang="en" lang="en" class="is-current" aria-current="true">English</a>
+          <a href="/zh/privacy-policy/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/privacy-policy/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/privacy-policy/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/privacy-policy/" hreflang="es" lang="es">Español</a>
+          <a href="/th/privacy-policy/" hreflang="th" lang="th">ไทย</a>
+        </div>
+      </div>
+    </header>
+
+    <section class="page-header">
+      <div class="container">
+        <h1>Privacy Policy</h1>
+        <p class="page-header__lead">About the information handled by Explores and the purposes for which it is used.</p>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <article class="prose">
+          <p>This privacy policy applies to the "Explores" mobile application (hereinafter the "App"), provided free of charge by Taiki Akamatsu (hereinafter the "Service Provider"). This service is provided on an "as is" basis.</p>
+
+          <h2>Information We Collect and How We Use It</h2>
+          <p>The App may collect the following information when it is downloaded and used.</p>
+          <ul>
+            <li>Your device's IP address</li>
+            <li>The pages you visit within the App, the date and time of your visits, and the time spent on them</li>
+            <li>The amount of time you spend using the App</li>
+            <li>The operating system of the mobile device you are using</li>
+          </ul>
+
+          <p>The App collects your device's location data. Location data is used to determine your approximate geographic location and is put to the following uses.</p>
+          <ul>
+            <li><strong>Location services</strong>: Providing personalized content, relevant recommendations, and location-based features</li>
+            <li><strong>Analytics and improvement</strong>: Analyzing user behavior and improving the overall performance of the App based on aggregated, anonymized location data</li>
+            <li><strong>Third-party services</strong>: We may transmit anonymized location data to external services that help us improve the App and optimize what we offer</li>
+          </ul>
+
+          <p>The Service Provider may use the information collected for the purpose of contacting you (for important announcements, necessary notifications, marketing communications, and the like). We may also ask you to provide certain personally identifiable information in order to offer a better experience, and that information will be used and retained as described in this policy.</p>
+
+          <h2>Sharing Information with Third Parties</h2>
+          <p>Only aggregated, anonymized data is transmitted to external services on a periodic basis. The Service Provider may share information with third parties in the manner described in this policy.</p>
+
+          <p>The App uses third-party services that have their own privacy policies. Please refer to the privacy policies of the third-party services we use below.</p>
+          <ul>
+            <li><a href="https://www.google.com/policies/privacy/" target="_blank" rel="noopener noreferrer">Google Play Services</a></li>
+          </ul>
+
+          <p>The Service Provider may disclose user-provided information and automatically collected information in any of the following circumstances.</p>
+          <ul>
+            <li>When required by law, such as to respond to a subpoena or similar legal process</li>
+            <li>When the Service Provider determines in good faith that disclosure is necessary to protect its rights, ensure the safety of users or third parties, investigate fraud, or respond to a government request</li>
+            <li>When working with trusted service providers acting on the Service Provider's behalf, who have agreed not to use the information independently and to comply with this policy</li>
+          </ul>
+
+          <h2>Opting Out</h2>
+          <p>You can stop all collection of information by uninstalling the App. Please use the standard uninstall procedure available on your device or through the app store.</p>
+
+          <h2>Data Retention</h2>
+          <p>The Service Provider retains user-provided data for as long as you use the App and for a reasonable period thereafter. If you wish to have the data you have provided through the App deleted, please contact us at <a href="mailto:akmatsutaiki@gmail.com">akmatsutaiki@gmail.com</a> and we will respond within a reasonable period of time.</p>
+
+          <h2>Children</h2>
+          <p>The Service Provider does not knowingly collect data from, or market to, children under the age of 13 through the App.</p>
+          <p>The App is not intended for children under the age of 13. If we discover that a child under the age of 13 has provided personal information, we will delete it from our servers immediately. If you are a parent or guardian and become aware that your child has provided personal information, please contact us at <a href="mailto:akmatsutaiki@gmail.com">akmatsutaiki@gmail.com</a>.</p>
+
+          <h2>Security</h2>
+          <p>The Service Provider is committed to keeping your information confidential. We have implemented physical, electronic, and procedural safeguards to protect the data we process and store.</p>
+
+          <h2>Changes to This Policy</h2>
+          <p>This privacy policy may be updated from time to time as necessary. The Service Provider will notify you of any changes by updating this page. Please check back periodically, as your continued use constitutes your agreement to all changes.</p>
+
+          <p>Effective date of this privacy policy: <strong>2024-05-06</strong></p>
+
+          <h2>Consent</h2>
+          <p>By using the App, you are deemed to have consented to the processing of your information in accordance with this privacy policy.</p>
+
+          <h2>Contact</h2>
+          <p>If you have any questions about privacy while using the App, or about this policy, please contact us by email at <a href="mailto:akmatsutaiki@gmail.com">akmatsutaiki@gmail.com</a>.</p>
+
+          <hr />
+          <p style="font-size: 0.86rem; color: var(--c-text-muted);">This policy was created using the <a href="https://app-privacy-policy-generator.nisrulz.com/" target="_blank" rel="noopener noreferrer">App Privacy Policy Generator</a>.</p>
+        </article>
+      </div>
+    </section>
+
+    <footer class="site-footer">
+      <div class="container">
+        <div class="site-footer__grid">
+          <div>
+            <div class="site-footer__brand">Explores</div>
+            <p class="site-footer__brand-line">A city-walking game that turns your stroll into an adventure.<br />by Prokonjo</p>
+          </div>
+          <div class="site-footer__col">
+            <h4>Site</h4>
+            <ul>
+              <li><a href="/en/#about">Features</a></li>
+              <li><a href="/en/#how">How to Play</a></li>
+              <li><a href="/en/#awards">Achievements</a></li>
+              <li><a href="/en/#faq">FAQ</a></li>
+            </ul>
+          </div>
+          <div class="site-footer__col">
+            <h4>About Us</h4>
+            <ul>
+              <li><a href="/en/privacy-policy/">Privacy Policy</a></li>
+              <li><a href="/en/#contact">Contact</a></li>
+              <li><a href="/en/tester-android/">Android Tester</a></li>
+            </ul>
+          </div>
+        </div>
+        <nav class="lang-switch" aria-label="Language / Language">
+          <span class="lang-switch__label">Language</span>
+          <a href="/privacy-policy/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/privacy-policy/" hreflang="en" lang="en" class="is-current" aria-current="true">English</a>
+          <a href="/zh/privacy-policy/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/privacy-policy/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/privacy-policy/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/privacy-policy/" hreflang="es" lang="es">Español</a>
+          <a href="/th/privacy-policy/" hreflang="th" lang="th">ไทย</a>
+        </nav>
+        <div class="site-footer__bottom">
+          <span>© 2024-2026 Prokonjo. All rights reserved.</span>
+          <div class="site-footer__social">
+            <a href="https://github.com/prokonjo-team" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+              <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      (function() {
+        var btn = document.querySelector('.menu-btn');
+        var menu = document.getElementById('mobile-menu');
+        if (!btn || !menu) return;
+        btn.addEventListener('click', function() {
+          var open = menu.dataset.open === 'true';
+          menu.dataset.open = open ? 'false' : 'true';
+          btn.setAttribute('aria-expanded', String(!open));
+        });
+        menu.querySelectorAll('a').forEach(function(a) {
+          a.addEventListener('click', function() {
+            menu.dataset.open = 'false';
+            btn.setAttribute('aria-expanded', 'false');
+          });
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/en/tester-android/index.html
+++ b/en/tester-android/index.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>Now Recruiting Android Testers｜Explores</title>
+    <meta name="description" content="The Android tester recruitment page for Explores. Join in 3 steps: register on Google Groups, install the app, and launch it." />
+    <meta name="theme-color" content="#FACD00" />
+    <meta name="robots" content="noindex" />
+    <link rel="canonical" href="https://prokonjo.com/en/tester-android/" />
+    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/tester-android/" />
+    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/tester-android/" />
+    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/tester-android/" />
+    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/tester-android/" />
+    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/tester-android/" />
+    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/tester-android/" />
+    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/tester-android/" />
+    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/tester-android/" />
+    <link rel="icon" type="image/png" href="/assets/favicon.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/css/styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-P3YYZEG46Z');
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container site-header__inner">
+        <a class="site-header__brand" href="/en/" aria-label="Explores home">
+          <span class="site-header__brand-mark" aria-hidden="true">🧭</span>
+          <span>Explores</span>
+        </a>
+        <nav class="site-nav" aria-label="Main menu">
+          <a href="/en/#about">Features</a>
+          <a href="/en/#how">How to Play</a>
+          <a href="/en/#awards">Achievements</a>
+          <a href="/en/#faq">FAQ</a>
+          <a href="/en/#contact">Contact</a>
+        </nav>
+        <a class="btn site-header__cta" href="/en/#download" aria-label="Download">
+          <svg class="site-header__cta-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>
+          <span class="site-header__cta-label">Download</span>
+        </a>
+        <button class="menu-btn" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+        </button>
+      </div>
+      <div id="mobile-menu" data-open="false">
+        <a href="/en/#about">Features</a>
+        <a href="/en/#how">How to Play</a>
+        <a href="/en/#awards">Achievements</a>
+        <a href="/en/#faq">FAQ</a>
+        <a href="/en/#contact">Contact</a>
+        <a href="/en/privacy-policy/">Privacy Policy</a>
+        <div class="mobile-menu__lang" aria-label="Language / Language">
+          <a href="/tester-android/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/tester-android/" hreflang="en" lang="en" class="is-current" aria-current="true">English</a>
+          <a href="/zh/tester-android/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/tester-android/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/tester-android/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/tester-android/" hreflang="es" lang="es">Español</a>
+          <a href="/th/tester-android/" hreflang="th" lang="th">ไทย</a>
+        </div>
+      </div>
+    </header>
+
+    <section class="page-header">
+      <div class="container">
+        <h1>Now Recruiting Android Testers</h1>
+        <p class="page-header__lead">Ahead of our Google Play launch, we're looking for people to play Explores early on Android. Join in just 3 steps!</p>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container container--narrow">
+        <div class="callout" style="margin-bottom: 2.5rem;">
+          <span class="callout__icon" aria-hidden="true">💡</span>
+          <div class="callout__body">
+            <strong>What we ask of testers</strong>
+            <p>Three things: installing the Android app (required), launching it (required), and answering a survey (optional).</p>
+          </div>
+        </div>
+
+        <div class="tester-step">
+          <div class="tester-step__num">1</div>
+          <div class="tester-step__body">
+            <h3>Register on Google Groups</h3>
+            <p>Join the Google Group via the link below. Unless you're in the tester Google Group, the app won't appear for you on Google Play.</p>
+            <a class="btn" href="https://groups.google.com/search?q=explores_tester&inOrg=false" target="_blank" rel="noopener noreferrer">Register on Google Groups</a>
+            <div class="tester-step__images">
+              <img src="/tester-android/imgs/1.png" alt="Google Groups registration step 1" loading="lazy" />
+              <img src="/tester-android/imgs/2.png" alt="Google Groups registration step 2" loading="lazy" />
+            </div>
+          </div>
+        </div>
+
+        <div class="tester-step">
+          <div class="tester-step__num">2</div>
+          <div class="tester-step__body">
+            <h3>Install the app</h3>
+            <p>Once your Google Groups registration has gone through, install the app from Google Play using the link below.</p>
+            <a class="btn" href="https://play.google.com/store/apps/details?id=com.prokonjo.explores" target="_blank" rel="noopener noreferrer">Install on Google Play</a>
+            <p style="margin-top: 1rem; font-size: 0.92rem;">If you see "The requested URL was not found on this server," your Google Groups registration may not have taken effect yet. Please wait a little while and try again.</p>
+          </div>
+        </div>
+
+        <div class="tester-step">
+          <div class="tester-step__num">3</div>
+          <div class="tester-step__body">
+            <h3>Launch the app</h3>
+            <p>After installing, launch the app once to complete your tester registration.</p>
+            <div class="callout">
+              <span class="callout__icon" aria-hidden="true">⚠️</span>
+              <div class="callout__body">
+                <strong>A favor to ask</strong>
+                <p>Once you've installed the app, please don't delete it. Uninstalling will remove you from the tester program.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="tester-step">
+          <div class="tester-step__num">+</div>
+          <div class="tester-step__body">
+            <h3>(Optional) Help us out with a survey</h3>
+            <p>Your feedback on how it feels to use the app helps us make it better.</p>
+            <a class="btn btn--secondary" href="https://docs.google.com/forms/d/1sWQDp1t_8PnzxENLO9BHw-IYn2yrNgumjZMQWQWam8I" target="_blank" rel="noopener noreferrer">Answer the survey</a>
+          </div>
+        </div>
+
+        <div style="text-align: center; margin-top: 3rem;">
+          <a class="btn btn--ghost" href="/en/">Back to top</a>
+        </div>
+      </div>
+    </section>
+
+    <footer class="site-footer">
+      <div class="container">
+        <div class="site-footer__grid">
+          <div>
+            <div class="site-footer__brand">Explores</div>
+            <p class="site-footer__brand-line">A city-walking game that turns a stroll into an adventure.<br />by Prokonjo</p>
+          </div>
+          <div class="site-footer__col">
+            <h4>Site</h4>
+            <ul>
+              <li><a href="/en/#about">Features</a></li>
+              <li><a href="/en/#how">How to Play</a></li>
+              <li><a href="/en/#awards">Achievements</a></li>
+              <li><a href="/en/#faq">FAQ</a></li>
+            </ul>
+          </div>
+          <div class="site-footer__col">
+            <h4>About Us</h4>
+            <ul>
+              <li><a href="/en/privacy-policy/">Privacy Policy</a></li>
+              <li><a href="/en/#contact">Contact</a></li>
+              <li><a href="/en/tester-android/">Android Testers</a></li>
+            </ul>
+          </div>
+        </div>
+        <nav class="lang-switch" aria-label="Language / Language">
+          <span class="lang-switch__label">Language</span>
+          <a href="/tester-android/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/tester-android/" hreflang="en" lang="en" class="is-current" aria-current="true">English</a>
+          <a href="/zh/tester-android/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/tester-android/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/tester-android/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/tester-android/" hreflang="es" lang="es">Español</a>
+          <a href="/th/tester-android/" hreflang="th" lang="th">ไทย</a>
+        </nav>
+        <div class="site-footer__bottom">
+          <span>© 2024-2026 Prokonjo. All rights reserved.</span>
+          <div class="site-footer__social">
+            <a href="https://github.com/prokonjo-team" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+              <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      (function() {
+        var btn = document.querySelector('.menu-btn');
+        var menu = document.getElementById('mobile-menu');
+        if (!btn || !menu) return;
+        btn.addEventListener('click', function() {
+          var open = menu.dataset.open === 'true';
+          menu.dataset.open = open ? 'false' : 'true';
+          btn.setAttribute('aria-expanded', String(!open));
+        });
+        menu.querySelectorAll('a').forEach(function(a) {
+          a.addEventListener('click', function() {
+            menu.dataset.open = 'false';
+            btn.setAttribute('aria-expanded', 'false');
+          });
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/es/index.html
+++ b/es/index.html
@@ -1,0 +1,450 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>Explores｜El juego de paseos urbanos que convierte tu caminata en aventura</title>
+    <meta name="description" content="Explores, el juego de paseos urbanos que convierte tu caminata en una aventura. Guíate por una foto y camina hacia lugares que no conoces. Unos 15 minutos por partida, gratis y sin compras dentro de la app." />
+    <meta name="author" content="Prokonjo" />
+    <meta name="theme-color" content="#FACD00" />
+    <link rel="canonical" href="https://prokonjo.com/es/" />
+
+    <!-- hreflang alternates -->
+    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/" />
+    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/" />
+    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/" />
+    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/" />
+    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/" />
+    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/" />
+    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/" />
+    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/" />
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Explores" />
+    <meta property="og:title" content="Explores｜El juego de paseos urbanos que convierte tu caminata en aventura" />
+    <meta property="og:description" content="Un juego de paseos urbanos en el que te guías por una foto para caminar hacia lugares que no conoces. Unos 15 minutos por partida, gratis y sin compras dentro de la app." />
+    <meta property="og:url" content="https://prokonjo.com/es/" />
+    <meta property="og:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+    <meta property="og:image:type" content="image/jpeg" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:locale" content="es_ES" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Explores｜El juego de paseos urbanos que convierte tu caminata en aventura" />
+    <meta name="twitter:description" content="Un juego de paseos urbanos en el que te guías por una foto para caminar hacia lugares que no conoces. Unos 15 minutos por partida, gratis y sin compras dentro de la app." />
+    <meta name="twitter:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" href="/assets/favicon.png" />
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+
+    <link rel="stylesheet" href="/css/styles.css" />
+
+    <!-- Structured data -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "MobileApplication",
+        "name": "Explores",
+        "description": "Un juego de paseos urbanos que convierte tu caminata en una aventura. Te guías por una foto para caminar hacia lugares que no conoces: una experiencia de exploración de unos 15 minutos por partida.",
+        "url": "https://prokonjo.com/",
+        "applicationCategory": "GameApplication",
+        "operatingSystem": "iOS",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "JPY"
+        },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Prokonjo",
+          "url": "https://prokonjo.com/"
+        }
+      }
+    </script>
+
+    <!-- Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-P3YYZEG46Z');
+    </script>
+  </head>
+  <body>
+    <!-- ==================== Header ==================== -->
+    <header class="site-header">
+      <div class="container site-header__inner">
+        <a class="site-header__brand" href="#top" aria-label="Explores inicio">
+          <span class="site-header__brand-mark" aria-hidden="true">🧭</span>
+          <span>Explores</span>
+        </a>
+        <nav class="site-nav" aria-label="Menú principal">
+          <a href="#about">Características</a>
+          <a href="#how">Cómo se juega</a>
+          <a href="#awards">Logros</a>
+          <a href="#faq">FAQ</a>
+          <a href="#contact">Contacto</a>
+        </nav>
+        <a class="btn site-header__cta" href="#download" aria-label="Descargar">
+          <svg class="site-header__cta-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>
+          <span class="site-header__cta-label">Descargar</span>
+        </a>
+        <button class="menu-btn" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Abrir menú">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+        </button>
+      </div>
+      <div id="mobile-menu" data-open="false">
+        <a href="#about">Características</a>
+        <a href="#how">Cómo se juega</a>
+        <a href="#awards">Logros</a>
+        <a href="#faq">FAQ</a>
+        <a href="#contact">Contacto</a>
+        <a href="/es/privacy-policy/">Política de privacidad</a>
+        <div class="mobile-menu__lang" aria-label="Idioma / Language">
+          <a href="/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/" hreflang="en" lang="en">English</a>
+          <a href="/zh/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/" hreflang="es" lang="es" class="is-current" aria-current="true">Español</a>
+          <a href="/th/" hreflang="th" lang="th">ไทย</a>
+        </div>
+      </div>
+    </header>
+
+    <!-- ==================== Hero ==================== -->
+    <section class="hero" id="top">
+      <div class="container hero__inner">
+        <div>
+          <span class="hero__eyebrow">🧭 Juego de exploración urbana</span>
+          <h1 class="hero__title">Convierte tu paseo en una <em>aventura</em>.</h1>
+          <p class="hero__sub">
+            Guíate por una foto y camina hacia lugares que no conoces.<br />
+            Unos 15 minutos por partida. Un juego de paseos urbanos gratis y sin compras dentro de la app.
+          </p>
+          <div class="hero__cta">
+            <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="Descargar en el App Store">
+              <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/es-es?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
+            </a>
+            <a class="btn btn--secondary" href="/es/tester-android">Android (buscamos probadores)</a>
+          </div>
+          <p class="hero__note">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>
+            Gratis ／ Sin compras dentro de la app ／ Sin anuncios
+          </p>
+        </div>
+        <div class="hero__visual">
+          <img src="/assets/img/game-desc.jpg" alt="Imagen de juego de Explores" width="1200" height="676" />
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Empathy ==================== -->
+    <section class="section section--alt" id="about">
+      <div class="container">
+        <h2 class="section__title">¿Te aburren los paseos de siempre?</h2>
+        <p class="section__lead">Aunque te propongas caminar para hacer ejercicio, el mismo camino cada día se vuelve imposible de mantener.<br />Quizá con un "paseo con un propósito" duraría un poco más.</p>
+        <div class="card-grid">
+          <div class="empathy-card">
+            <div class="empathy-card__icon" aria-hidden="true">🛣️</div>
+            <h3>El mismo camino, día tras día, aburre</h3>
+            <p>Ida y vuelta entre casa y la estación. Y, sin darte cuenta, caminas sin mirar el paisaje.</p>
+          </div>
+          <div class="empathy-card">
+            <div class="empathy-card__icon" aria-hidden="true">📉</div>
+            <h3>No se vuelve hábito y lo dejas</h3>
+            <p>Te dices "voy a caminar", pero a los tres días ya se te olvidó.</p>
+          </div>
+          <div class="empathy-card">
+            <div class="empathy-card__icon" aria-hidden="true">🤔</div>
+            <h3>No tienes una razón para caminar</h3>
+            <p>Si solo es por hacer ejercicio, la motivación no aguanta.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Value ==================== -->
+    <section class="section">
+      <div class="container">
+        <h2 class="section__title">Con Explores,<br />el paseo se vuelve aventura.</h2>
+        <p class="section__lead">Con solo una foto como pista, vas hacia un lugar que no conoces.<br />Una meta distinta cada vez. Listo en 15 minutos. Aquí está tu "razón para caminar".</p>
+        <div class="card-grid">
+          <div class="value-card">
+            <div class="value-card__badge">01</div>
+            <h3>Una meta distinta cada vez</h3>
+            <p>Según el tiempo que elijas, el destino se decide al azar en cada partida. No te cansarás de ir siempre al mismo sitio.</p>
+          </div>
+          <div class="value-card">
+            <div class="value-card__badge">02</div>
+            <h3>Pistas en foto que dan emoción</h3>
+            <p>No caminas con un mapa, sino guiándote por fotos de los alrededores del destino. "Ese edificio lo he visto en algún lado…": ahí empieza la aventura.</p>
+          </div>
+          <div class="value-card">
+            <div class="value-card__badge">03</div>
+            <h3>Listo en 15 minutos</h3>
+            <p>De vuelta del trabajo, en un descanso, en el paseo del fin de semana. Lo bastante ligero como para empezar cuando quieras y dejarlo cuando quieras.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== How ==================== -->
+    <section class="section section--surface" id="how">
+      <div class="container">
+        <h2 class="section__title">Cómo se juega: 3 pasos</h2>
+        <p class="section__lead">Solo 30 segundos desde que abres la app hasta que sales a la calle.</p>
+        <div class="steps">
+          <div class="step">
+            <div class="step__num">1</div>
+            <img class="step__img" src="/assets/img/game-play0.png" alt="Pantalla de selección de tiempo" loading="lazy" />
+            <h3>Elige el tiempo</h3>
+            <p>Elige cuánto quieres caminar. "15 minutos", "30 minutos"... lo que te apetezca en ese momento.</p>
+          </div>
+          <div class="step">
+            <div class="step__num">2</div>
+            <img class="step__img" src="/assets/img/game-play1.png" alt="Pantalla para revisar las fotos y el mapa de los alrededores del destino" loading="lazy" />
+            <h3>Memoriza el destino</h3>
+            <p>Antes de empezar la partida, fíjate bien en las fotos y el mapa de los alrededores del destino. En cuanto empieces, desaparecen.</p>
+          </div>
+          <div class="step">
+            <div class="step__num">3</div>
+            <img class="step__img" src="/assets/img/game-play2.png" alt="Pantalla del juego durante la exploración" loading="lazy" />
+            <h3>Camina de memoria</h3>
+            <p>Guíate solo por el tiempo restante y la distancia para llegar al destino. "¡Ey, ese es el paisaje de la foto!"</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Video ==================== -->
+    <section class="section">
+      <div class="container">
+        <h2 class="section__title">Explores en vídeo</h2>
+        <p class="section__lead">Aquí tienes una partida real y un paseo por la ciudad.</p>
+        <div class="video-wrap">
+          <iframe src="https://www.youtube.com/embed/ldIJdk3zwHY?si=jwntDJV8pnRAHKio" title="Vídeo de presentación de cómo se juega a Explores" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Awards ==================== -->
+    <section class="section section--alt" id="awards">
+      <div class="container">
+        <h2 class="section__title">Premios</h2>
+        <p class="section__lead">Logros en concursos acumulados desde nuestra época de estudiantes.</p>
+        <div class="awards">
+          <article class="award">
+            <img src="/assets/img/award-gikuhaku.jpg" alt="Premio de la empresa patrocinadora en Gikuhaku" loading="lazy" />
+            <div class="award__body">
+              <span class="award__tag">Premio de empresa</span>
+              <h3>Gikuhaku</h3>
+              <p>En Gikuhaku, organizado por Supporterz, Explores recibió el premio de la empresa patrocinadora.</p>
+              <a class="award__link" href="https://x.com/geek_pjt/status/1789225529109057540" target="_blank" rel="noopener noreferrer">Ver la publicación del premio →</a>
+            </div>
+          </article>
+          <article class="award">
+            <img src="/assets/img/award-wakayama.jpg" alt="Gran premio del Concurso de Programación e Innovación de Wakayama" loading="lazy" />
+            <div class="award__body">
+              <span class="award__tag">Gran premio</span>
+              <h3>Concurso de Programación e Innovación de Wakayama</h3>
+              <p>Gran premio por una propuesta de app móvil que resuelve problemas existentes en Wakayama.</p>
+              <a class="award__link" href="https://wakayama-innovation-lab.relic.co.jp/" target="_blank" rel="noopener noreferrer">Ver la información del organizador →</a>
+            </div>
+          </article>
+          <article class="award">
+            <img src="/assets/img/award-iizuka.jpg" alt="Premio del Alcalde en el e-ZUKA Smart App Contest 2023" loading="lazy" />
+            <div class="award__body">
+              <span class="award__tag">Premio del Alcalde + Premio de empresa</span>
+              <h3>e-ZUKA Smart App Contest 2023</h3>
+              <p>En el concurso organizado por la ciudad de Iizuka (prefectura de Fukuoka), doble premio: el del Alcalde de Iizuka y el de la empresa patrocinadora.</p>
+              <a class="award__link" href="http://e-zuka.info/2023/resurt.html" target="_blank" rel="noopener noreferrer">Ver los resultados del concurso →</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Members ==================== -->
+    <section class="section" id="members">
+      <div class="container">
+        <h2 class="section__title">El equipo de desarrollo</h2>
+        <p class="section__lead">Un equipo de 4 personas que se toma muy en serio "convertir el paseo en aventura".</p>
+        <div class="members">
+          <div class="member">
+            <img src="/assets/img/member-akamatsu.png" alt="Taiki Akamatsu" loading="lazy" width="96" height="96" />
+            <h3>Taiki Akamatsu</h3>
+            <p>Director / Ingeniero</p>
+            <div class="member__links">
+              <a href="https://www.wantedly.com/id/akamatsu_taiki" target="_blank" rel="noopener noreferrer" aria-label="Perfil de Wantedly">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3a14 14 0 010 18M12 3a14 14 0 000 18"/></svg>
+              </a>
+              <a href="https://github.com/Taiki-sub" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+              </a>
+            </div>
+          </div>
+          <div class="member">
+            <img src="/assets/img/member-chang.png" alt="Chang Juyoung" loading="lazy" width="96" height="96" />
+            <h3>張珠煐</h3>
+            <p>Diseñadora</p>
+          </div>
+          <div class="member">
+            <img src="/assets/img/siteTop4.jpg" alt="Kento Kusumoto" loading="lazy" width="96" height="96" />
+            <h3>楠本健人</h3>
+            <p>Diseñador</p>
+          </div>
+          <div class="member">
+            <img src="/assets/img/member-hayashi.png" alt="Shinichiro Hayashi" loading="lazy" width="96" height="96" />
+            <h3>林慎一郎</h3>
+            <p>Ingeniero</p>
+            <div class="member__links">
+              <a href="https://www.github.com/hashin2425" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== FAQ ==================== -->
+    <section class="section section--surface" id="faq">
+      <div class="container">
+        <h2 class="section__title">Preguntas frecuentes</h2>
+        <p class="section__lead">Hemos reunido las dudas más habituales antes de jugar.</p>
+        <div class="faq">
+          <details>
+            <summary>¿De verdad es gratis? ¿Hay compras dentro de la app?</summary>
+            <p>Es totalmente gratis. No hay ningún tipo de compra dentro de la app, ni gachas ni suscripciones. De momento tampoco mostramos anuncios.</p>
+          </details>
+          <details>
+            <summary>¿Cuánto dura una partida?</summary>
+            <p>Puedes elegir entre 15, 20 o 30 minutos, según lo que te apetezca en ese momento. Sirve igual para un huequito corto que para un fin de semana en el que quieras caminar a tope.</p>
+          </details>
+          <details>
+            <summary>¿Dónde se puede jugar?</summary>
+            <p>En general puedes disfrutarlo en cualquier zona urbana. A partir de tu información de GPS, se genera automáticamente una meta dentro de un radio al que puedas llegar caminando desde tu ubicación actual.</p>
+          </details>
+          <details>
+            <summary>¿Cuánto consume de datos y batería?</summary>
+            <p>Como obtiene la ubicación de forma continua, jugar durante mucho tiempo tiende a gastar batería. El consumo de datos es sobre todo el de mostrar el mapa, así que no es excesivo.</p>
+          </details>
+          <details>
+            <summary>¿Qué precauciones debo tomar para jugar con seguridad?</summary>
+            <p>Ten muchísimo cuidado de no manejar el móvil mientras caminas. Detente antes de cruzar los pasos de peatones, evita las calles oscuras y las zonas solitarias y, en general, respeta siempre las reglas básicas de seguridad al pasear.</p>
+          </details>
+          <details>
+            <summary>¿Hay versión para Android?</summary>
+            <p>Ahora mismo buscamos probadores de cara a la publicación en Google Play. Puedes registrarte como probador desde <a href="/es/tester-android">esta página</a>.</p>
+          </details>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Final CTA ==================== -->
+    <section class="section cta-section" id="download">
+      <div class="container container--narrow">
+        <h2>Venga, convierte tu paseo en una aventura.</h2>
+        <p>Descárgalo ahora mismo y da el primer paso hacia un lugar que no conoces.</p>
+        <div class="hero__cta" style="justify-content: center;">
+          <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="Descargar en el App Store">
+            <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/es-es?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
+          </a>
+          <a class="btn" href="/es/tester-android" style="background:#fff;">Android (buscamos probadores)</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Contact ==================== -->
+    <section class="section" id="contact">
+      <div class="container">
+        <h2 class="section__title">Contacto</h2>
+        <p class="section__lead">Informes de errores, opiniones, propuestas de colaboración... escríbenos sin reparos.</p>
+        <div class="contact-card">
+          <p>Ponte en contacto por correo desde el siguiente botón.</p>
+          <a class="btn btn--lg" href="mailto:akmatsutaiki@gmail.com?subject=%E3%80%90%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%A9%E3%83%BC%E3%82%BA%E3%80%91%E3%81%8A%E5%95%8F%E3%81%84%E5%90%88%E3%82%8F%E3%81%9B">
+            Contactar por correo
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Footer ==================== -->
+    <footer class="site-footer">
+      <div class="container">
+        <div class="site-footer__grid">
+          <div>
+            <div class="site-footer__brand">Explores</div>
+            <p class="site-footer__brand-line">El juego de paseos urbanos que convierte tu caminata en aventura.<br />by Prokonjo</p>
+          </div>
+          <div class="site-footer__col">
+            <h4>Sitio</h4>
+            <ul>
+              <li><a href="#about">Características</a></li>
+              <li><a href="#how">Cómo se juega</a></li>
+              <li><a href="#awards">Logros</a></li>
+              <li><a href="#faq">FAQ</a></li>
+            </ul>
+          </div>
+          <div class="site-footer__col">
+            <h4>Información</h4>
+            <ul>
+              <li><a href="/es/privacy-policy/">Política de privacidad</a></li>
+              <li><a href="#contact">Contacto</a></li>
+              <li><a href="/es/tester-android">Probadores de Android</a></li>
+            </ul>
+          </div>
+        </div>
+        <nav class="lang-switch" aria-label="Idioma / Language">
+          <span class="lang-switch__label">Idioma</span>
+          <a href="/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/" hreflang="en" lang="en">English</a>
+          <a href="/zh/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/" hreflang="es" lang="es" class="is-current" aria-current="true">Español</a>
+          <a href="/th/" hreflang="th" lang="th">ไทย</a>
+        </nav>
+        <div class="site-footer__bottom">
+          <span>© 2024-2026 Prokonjo. All rights reserved.</span>
+          <div class="site-footer__social">
+            <a href="https://github.com/prokonjo-team" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+              <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      // Mobile menu toggle
+      (function() {
+        var btn = document.querySelector('.menu-btn');
+        var menu = document.getElementById('mobile-menu');
+        if (!btn || !menu) return;
+        btn.addEventListener('click', function() {
+          var open = menu.dataset.open === 'true';
+          menu.dataset.open = open ? 'false' : 'true';
+          btn.setAttribute('aria-expanded', String(!open));
+        });
+        // Close on link tap
+        menu.querySelectorAll('a').forEach(function(a) {
+          a.addEventListener('click', function() {
+            menu.dataset.open = 'false';
+            btn.setAttribute('aria-expanded', 'false');
+          });
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/es/privacy-policy/index.html
+++ b/es/privacy-policy/index.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>Política de privacidad｜Explores</title>
+    <meta name="description" content="Política de privacidad de Explores. Sobre el tratamiento de los datos de ubicación y el período de conservación de los datos." />
+    <meta name="theme-color" content="#FACD00" />
+    <meta name="robots" content="noindex" />
+    <link rel="canonical" href="https://prokonjo.com/es/privacy-policy/" />
+    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/privacy-policy/" />
+    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/privacy-policy/" />
+    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/privacy-policy/" />
+    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/privacy-policy/" />
+    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/privacy-policy/" />
+    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/privacy-policy/" />
+    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/privacy-policy/" />
+    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/privacy-policy/" />
+    <link rel="icon" type="image/png" href="/assets/favicon.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/css/styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-P3YYZEG46Z');
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container site-header__inner">
+        <a class="site-header__brand" href="/es/" aria-label="Inicio de Explores">
+          <span class="site-header__brand-mark" aria-hidden="true">🧭</span>
+          <span>Explores</span>
+        </a>
+        <nav class="site-nav" aria-label="Menú principal">
+          <a href="/es/#about">Características</a>
+          <a href="/es/#how">Cómo se juega</a>
+          <a href="/es/#awards">Logros</a>
+          <a href="/es/#faq">FAQ</a>
+          <a href="/es/#contact">Contacto</a>
+        </nav>
+        <a class="btn site-header__cta" href="/es/#download" aria-label="Descargar">
+          <svg class="site-header__cta-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>
+          <span class="site-header__cta-label">Descargar</span>
+        </a>
+        <button class="menu-btn" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Abrir menú">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+        </button>
+      </div>
+      <div id="mobile-menu" data-open="false">
+        <a href="/es/#about">Características</a>
+        <a href="/es/#how">Cómo se juega</a>
+        <a href="/es/#awards">Logros</a>
+        <a href="/es/#faq">FAQ</a>
+        <a href="/es/#contact">Contacto</a>
+        <a href="/es/privacy-policy/">Política de privacidad</a>
+        <div class="mobile-menu__lang" aria-label="Idioma / Language">
+          <a href="/privacy-policy/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/privacy-policy/" hreflang="en" lang="en">English</a>
+          <a href="/zh/privacy-policy/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/privacy-policy/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/privacy-policy/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/privacy-policy/" hreflang="es" lang="es" class="is-current" aria-current="true">Español</a>
+          <a href="/th/privacy-policy/" hreflang="th" lang="th">ไทย</a>
+        </div>
+      </div>
+    </header>
+
+    <section class="page-header">
+      <div class="container">
+        <h1>Política de privacidad</h1>
+        <p class="page-header__lead">Sobre la información que tratamos en Explores y su finalidad de uso.</p>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <article class="prose">
+          <p>Esta política de privacidad se aplica a la aplicación móvil «Explores» (en adelante, «la Aplicación»), que Taiki Akamatsu (en adelante, «el Proveedor del Servicio») ofrece de forma gratuita. El servicio se proporciona partiendo de un uso «tal cual».</p>
+
+          <h2>Información que se recopila y finalidad de uso</h2>
+          <p>La Aplicación puede recopilar información como la siguiente durante su descarga y uso.</p>
+          <ul>
+            <li>La dirección IP del dispositivo</li>
+            <li>Las páginas visitadas dentro de la Aplicación, la fecha y hora de visita y el tiempo de permanencia</li>
+            <li>El tiempo de uso de la Aplicación</li>
+            <li>El sistema operativo del dispositivo móvil utilizado</li>
+          </ul>
+
+          <p>La Aplicación recopila los datos de ubicación del dispositivo. Estos datos se utilizan para determinar la ubicación geográfica aproximada y se emplean para los siguientes fines.</p>
+          <ul>
+            <li><strong>Servicios de ubicación</strong>: ofrecer contenido personalizado, recomendaciones relevantes y funciones basadas en la ubicación</li>
+            <li><strong>Análisis y mejora</strong>: analizar el comportamiento de los usuarios y mejorar el rendimiento general de la Aplicación a partir de datos de ubicación agregados y anonimizados</li>
+            <li><strong>Servicios de terceros</strong>: en algunos casos, los datos de ubicación anonimizados pueden enviarse a servicios externos que ayudan a mejorar la Aplicación y a optimizar el contenido ofrecido</li>
+          </ul>
+
+          <p>El Proveedor del Servicio puede utilizar la información obtenida para ponerse en contacto con usted (avisos importantes, notificaciones necesarias, comunicaciones de marketing, etc.). Asimismo, para ofrecerle una mejor experiencia, es posible que le solicitemos cierta información que permita identificarle de forma personal, y dicha información se utilizará y conservará según lo descrito en esta política.</p>
+
+          <h2>Cesión de información a terceros</h2>
+          <p>A los servicios externos solo se les envían periódicamente datos agregados y anonimizados. El Proveedor del Servicio puede compartir información con terceros del modo descrito en esta política.</p>
+
+          <p>La Aplicación utiliza servicios de terceros que cuentan con su propia política de privacidad. Consulte a continuación la política de privacidad de los servicios de terceros utilizados.</p>
+          <ul>
+            <li><a href="https://www.google.com/policies/privacy/" target="_blank" rel="noopener noreferrer">Google Play Services</a></li>
+          </ul>
+
+          <p>El Proveedor del Servicio puede divulgar la información proporcionada por el usuario y la información recopilada automáticamente cuando se dé alguno de los siguientes supuestos.</p>
+          <ul>
+            <li>Cuando lo exija la ley, por ejemplo para responder a una citación judicial o a un procedimiento legal equivalente</li>
+            <li>Cuando se considere de buena fe que es necesario para proteger los derechos del Proveedor del Servicio, garantizar la seguridad de los usuarios o de terceros, investigar fraudes o responder a una solicitud gubernamental</li>
+            <li>Cuando se trate de proveedores de servicios de confianza que actúen en nombre del Proveedor del Servicio y hayan aceptado no utilizar la información de forma independiente y atenerse a esta política</li>
+          </ul>
+
+          <h2>Sobre la exclusión voluntaria (opt-out)</h2>
+          <p>Puede detener por completo la recopilación de información desinstalando la Aplicación. Utilice el procedimiento de desinstalación estándar de su dispositivo o de la tienda de aplicaciones.</p>
+
+          <h2>Período de conservación de los datos</h2>
+          <p>El Proveedor del Servicio conservará los datos proporcionados por el usuario mientras utilice la Aplicación y durante el período que se considere razonable. Si desea eliminar los datos que ha proporcionado a través de la Aplicación, póngase en contacto con <a href="mailto:akmatsutaiki@gmail.com">akmatsutaiki@gmail.com</a>. Atenderemos su solicitud en un plazo razonable.</p>
+
+          <h2>Sobre el uso por parte de menores</h2>
+          <p>El Proveedor del Servicio no recopila intencionadamente datos de menores de 13 años a través de la Aplicación ni les dirige acciones de marketing.</p>
+          <p>La Aplicación no está dirigida a menores de 13 años. En el caso de que se descubra que un menor de 13 años ha proporcionado datos personales, estos se eliminarán de inmediato del servidor. Si usted es padre, madre o tutor y descubre que su hijo o hija ha proporcionado datos personales, póngase en contacto con <a href="mailto:akmatsutaiki@gmail.com">akmatsutaiki@gmail.com</a>.</p>
+
+          <h2>Seguridad</h2>
+          <p>El Proveedor del Servicio se esfuerza por mantener la confidencialidad de su información. Para proteger los datos que procesa y almacena, aplica medidas de seguridad físicas, electrónicas y de procedimiento.</p>
+
+          <h2>Cambios en esta política</h2>
+          <p>Esta política de privacidad puede actualizarse en cualquier momento según sea necesario. El Proveedor del Servicio le informará de los cambios actualizando esta página. El uso continuado se considerará como su aceptación de todos los cambios, por lo que le recomendamos consultarla periódicamente.</p>
+
+          <p>Fecha de entrada en vigor de esta política de privacidad: <strong>2024-05-06</strong></p>
+
+          <h2>Sobre el consentimiento</h2>
+          <p>El uso de la Aplicación implica que usted acepta el tratamiento de su información conforme a esta política de privacidad.</p>
+
+          <h2>Contacto</h2>
+          <p>Si tiene alguna pregunta sobre la privacidad durante el uso de la Aplicación o sobre esta política, póngase en contacto por correo electrónico en <a href="mailto:akmatsutaiki@gmail.com">akmatsutaiki@gmail.com</a>.</p>
+
+          <hr />
+          <p style="font-size: 0.86rem; color: var(--c-text-muted);">Para la elaboración de esta política se utilizó <a href="https://app-privacy-policy-generator.nisrulz.com/" target="_blank" rel="noopener noreferrer">App Privacy Policy Generator</a>.</p>
+        </article>
+      </div>
+    </section>
+
+    <footer class="site-footer">
+      <div class="container">
+        <div class="site-footer__grid">
+          <div>
+            <div class="site-footer__brand">Explores</div>
+            <p class="site-footer__brand-line">El juego de paseos urbanos que convierte tus caminatas en aventuras.<br />by Prokonjo (prokonjo)</p>
+          </div>
+          <div class="site-footer__col">
+            <h4>Sitio</h4>
+            <ul>
+              <li><a href="/es/#about">Características</a></li>
+              <li><a href="/es/#how">Cómo se juega</a></li>
+              <li><a href="/es/#awards">Logros</a></li>
+              <li><a href="/es/#faq">FAQ</a></li>
+            </ul>
+          </div>
+          <div class="site-footer__col">
+            <h4>Información del operador</h4>
+            <ul>
+              <li><a href="/es/privacy-policy/">Política de privacidad</a></li>
+              <li><a href="/es/#contact">Contacto</a></li>
+              <li><a href="/es/tester-android/">Tester de Android</a></li>
+            </ul>
+          </div>
+        </div>
+        <nav class="lang-switch" aria-label="Idioma / Language">
+          <span class="lang-switch__label">Idioma</span>
+          <a href="/privacy-policy/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/privacy-policy/" hreflang="en" lang="en">English</a>
+          <a href="/zh/privacy-policy/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/privacy-policy/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/privacy-policy/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/privacy-policy/" hreflang="es" lang="es" class="is-current" aria-current="true">Español</a>
+          <a href="/th/privacy-policy/" hreflang="th" lang="th">ไทย</a>
+        </nav>
+        <div class="site-footer__bottom">
+          <span>© 2024-2026 Prokonjo (prokonjo). All rights reserved.</span>
+          <div class="site-footer__social">
+            <a href="https://github.com/prokonjo-team" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+              <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      (function() {
+        var btn = document.querySelector('.menu-btn');
+        var menu = document.getElementById('mobile-menu');
+        if (!btn || !menu) return;
+        btn.addEventListener('click', function() {
+          var open = menu.dataset.open === 'true';
+          menu.dataset.open = open ? 'false' : 'true';
+          btn.setAttribute('aria-expanded', String(!open));
+        });
+        menu.querySelectorAll('a').forEach(function(a) {
+          a.addEventListener('click', function() {
+            menu.dataset.open = 'false';
+            btn.setAttribute('aria-expanded', 'false');
+          });
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/es/tester-android/index.html
+++ b/es/tester-android/index.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>Buscamos testers de Android｜Explores</title>
+    <meta name="description" content="Página de reclutamiento de testers de Android de Explores. En 3 pasos: registrarte en Google Groups, instalar la app y abrirla." />
+    <meta name="theme-color" content="#FACD00" />
+    <meta name="robots" content="noindex" />
+    <link rel="canonical" href="https://prokonjo.com/es/tester-android/" />
+    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/tester-android/" />
+    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/tester-android/" />
+    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/tester-android/" />
+    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/tester-android/" />
+    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/tester-android/" />
+    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/tester-android/" />
+    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/tester-android/" />
+    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/tester-android/" />
+    <link rel="icon" type="image/png" href="/assets/favicon.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/css/styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-P3YYZEG46Z');
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container site-header__inner">
+        <a class="site-header__brand" href="/es/" aria-label="Inicio de Explores">
+          <span class="site-header__brand-mark" aria-hidden="true">🧭</span>
+          <span>Explores</span>
+        </a>
+        <nav class="site-nav" aria-label="Main menu">
+          <a href="/es/#about">Características</a>
+          <a href="/es/#how">Cómo se juega</a>
+          <a href="/es/#awards">Logros</a>
+          <a href="/es/#faq">FAQ</a>
+          <a href="/es/#contact">Contacto</a>
+        </nav>
+        <a class="btn site-header__cta" href="/es/#download" aria-label="Descargar">
+          <svg class="site-header__cta-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>
+          <span class="site-header__cta-label">Descargar</span>
+        </a>
+        <button class="menu-btn" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+        </button>
+      </div>
+      <div id="mobile-menu" data-open="false">
+        <a href="/es/#about">Características</a>
+        <a href="/es/#how">Cómo se juega</a>
+        <a href="/es/#awards">Logros</a>
+        <a href="/es/#faq">FAQ</a>
+        <a href="/es/#contact">Contacto</a>
+        <a href="/es/privacy-policy/">Política de privacidad</a>
+        <div class="mobile-menu__lang" aria-label="Idioma / Language">
+          <a href="/tester-android/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/tester-android/" hreflang="en" lang="en">English</a>
+          <a href="/zh/tester-android/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/tester-android/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/tester-android/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/tester-android/" hreflang="es" lang="es" class="is-current" aria-current="true">Español</a>
+          <a href="/th/tester-android/" hreflang="th" lang="th">ไทย</a>
+        </div>
+      </div>
+    </header>
+
+    <section class="page-header">
+      <div class="container">
+        <h1>Buscamos testers de Android</h1>
+        <p class="page-header__lead">De cara al lanzamiento en Google Play, buscamos personas que quieran probar Explores en Android antes que nadie. ¡Apúntate en solo 3 pasos!</p>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container container--narrow">
+        <div class="callout" style="margin-bottom: 2.5rem;">
+          <span class="callout__icon" aria-hidden="true">💡</span>
+          <div class="callout__body">
+            <strong>Lo que te pedimos como tester</strong>
+            <p>Son tres cosas: instalar la app de Android (obligatorio), abrirla (obligatorio) y responder la encuesta (opcional).</p>
+          </div>
+        </div>
+
+        <div class="tester-step">
+          <div class="tester-step__num">1</div>
+          <div class="tester-step__body">
+            <h3>Regístrate en Google Groups</h3>
+            <p>Únete a Google Groups desde el enlace de abajo. Si no estás en el Google Groups de testers, la app no aparecerá en Google Play.</p>
+            <a class="btn" href="https://groups.google.com/search?q=explores_tester&inOrg=false" target="_blank" rel="noopener noreferrer">Registrarse en Google Groups</a>
+            <div class="tester-step__images">
+              <img src="/tester-android/imgs/1.png" alt="Pasos para registrarse en Google Groups 1" loading="lazy" />
+              <img src="/tester-android/imgs/2.png" alt="Pasos para registrarse en Google Groups 2" loading="lazy" />
+            </div>
+          </div>
+        </div>
+
+        <div class="tester-step">
+          <div class="tester-step__num">2</div>
+          <div class="tester-step__body">
+            <h3>Instala la app</h3>
+            <p>Una vez que tu registro en Google Groups se haya aplicado, instala la app desde Google Play usando el enlace de abajo.</p>
+            <a class="btn" href="https://play.google.com/store/apps/details?id=com.prokonjo.explores" target="_blank" rel="noopener noreferrer">Instalar desde Google Play</a>
+            <p style="margin-top: 1rem; font-size: 0.92rem;">Si aparece el mensaje «No se encontró la URL solicitada en este servidor.», es posible que tu registro en Google Groups aún no se haya aplicado. Espera un momento y vuelve a intentarlo.</p>
+          </div>
+        </div>
+
+        <div class="tester-step">
+          <div class="tester-step__num">3</div>
+          <div class="tester-step__body">
+            <h3>Abre la app</h3>
+            <p>Después de instalarla, abre la app una vez para completar tu registro como tester.</p>
+            <div class="callout">
+              <span class="callout__icon" aria-hidden="true">⚠️</span>
+              <div class="callout__body">
+                <strong>Un favor</strong>
+                <p>Una vez instalada, te pedimos que no elimines la app. Si la desinstalas, dejarás de ser tester.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="tester-step">
+          <div class="tester-step__num">+</div>
+          <div class="tester-step__body">
+            <h3>(Opcional) Ayúdanos con la encuesta</h3>
+            <p>Tu opinión sobre la experiencia de uso nos ayuda mucho a mejorar la app.</p>
+            <a class="btn btn--secondary" href="https://docs.google.com/forms/d/1sWQDp1t_8PnzxENLO9BHw-IYn2yrNgumjZMQWQWam8I" target="_blank" rel="noopener noreferrer">Responder la encuesta</a>
+          </div>
+        </div>
+
+        <div style="text-align: center; margin-top: 3rem;">
+          <a class="btn btn--ghost" href="/es/">Volver al inicio</a>
+        </div>
+      </div>
+    </section>
+
+    <footer class="site-footer">
+      <div class="container">
+        <div class="site-footer__grid">
+          <div>
+            <div class="site-footer__brand">Explores</div>
+            <p class="site-footer__brand-line">Un juego de paseos urbanos que convierte cada caminata en una aventura.<br />by Prokonjo (prokonjo)</p>
+          </div>
+          <div class="site-footer__col">
+            <h4>Sitio</h4>
+            <ul>
+              <li><a href="/es/#about">Características</a></li>
+              <li><a href="/es/#how">Cómo se juega</a></li>
+              <li><a href="/es/#awards">Logros</a></li>
+              <li><a href="/es/#faq">FAQ</a></li>
+            </ul>
+          </div>
+          <div class="site-footer__col">
+            <h4>Información</h4>
+            <ul>
+              <li><a href="/es/privacy-policy/">Política de privacidad</a></li>
+              <li><a href="/es/#contact">Contacto</a></li>
+              <li><a href="/es/tester-android/">Testers de Android</a></li>
+            </ul>
+          </div>
+        </div>
+        <nav class="lang-switch" aria-label="Idioma / Language">
+          <span class="lang-switch__label">Idioma</span>
+          <a href="/tester-android/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/tester-android/" hreflang="en" lang="en">English</a>
+          <a href="/zh/tester-android/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/tester-android/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/tester-android/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/tester-android/" hreflang="es" lang="es" class="is-current" aria-current="true">Español</a>
+          <a href="/th/tester-android/" hreflang="th" lang="th">ไทย</a>
+        </nav>
+        <div class="site-footer__bottom">
+          <span>© 2024-2026 Prokonjo (prokonjo). All rights reserved.</span>
+          <div class="site-footer__social">
+            <a href="https://github.com/prokonjo-team" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+              <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      (function() {
+        var btn = document.querySelector('.menu-btn');
+        var menu = document.getElementById('mobile-menu');
+        if (!btn || !menu) return;
+        btn.addEventListener('click', function() {
+          var open = menu.dataset.open === 'true';
+          menu.dataset.open = open ? 'false' : 'true';
+          btn.setAttribute('aria-expanded', String(!open));
+        });
+        menu.querySelectorAll('a').forEach(function(a) {
+          a.addEventListener('click', function() {
+            menu.dataset.open = 'false';
+            btn.setAttribute('aria-expanded', 'false');
+          });
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/fr/index.html
+++ b/fr/index.html
@@ -1,0 +1,450 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>Explores｜Le jeu de balade urbaine qui transforme vos promenades en aventures</title>
+    <meta name="description" content="Explores, le jeu de balade urbaine qui transforme la promenade en aventure. Guidé par des photos, partez à pied vers des lieux inconnus. Environ 15 min par partie, gratuit, sans achats intégrés." />
+    <meta name="author" content="Prokonjo" />
+    <meta name="theme-color" content="#FACD00" />
+    <link rel="canonical" href="https://prokonjo.com/fr/" />
+
+    <!-- hreflang alternates -->
+    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/" />
+    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/" />
+    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/" />
+    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/" />
+    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/" />
+    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/" />
+    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/" />
+    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/" />
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Explores" />
+    <meta property="og:title" content="Explores｜Le jeu de balade urbaine qui transforme vos promenades en aventures" />
+    <meta property="og:description" content="Le jeu de balade urbaine où, guidé par des photos, vous partez à pied vers des lieux inconnus. Environ 15 min par partie, gratuit, sans achats intégrés." />
+    <meta property="og:url" content="https://prokonjo.com/fr/" />
+    <meta property="og:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+    <meta property="og:image:type" content="image/jpeg" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:locale" content="fr_FR" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Explores｜Le jeu de balade urbaine qui transforme vos promenades en aventures" />
+    <meta name="twitter:description" content="Le jeu de balade urbaine où, guidé par des photos, vous partez à pied vers des lieux inconnus. Environ 15 min par partie, gratuit, sans achats intégrés." />
+    <meta name="twitter:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" href="/assets/favicon.png" />
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+
+    <link rel="stylesheet" href="/css/styles.css" />
+
+    <!-- Structured data -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "MobileApplication",
+        "name": "Explores",
+        "description": "Le jeu de balade urbaine qui transforme la promenade en aventure. Guidé par des photos, partez à pied vers des lieux inconnus : une expérience d'exploration d'environ 15 minutes par partie.",
+        "url": "https://prokonjo.com/",
+        "applicationCategory": "GameApplication",
+        "operatingSystem": "iOS",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "JPY"
+        },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Prokonjo",
+          "url": "https://prokonjo.com/"
+        }
+      }
+    </script>
+
+    <!-- Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-P3YYZEG46Z');
+    </script>
+  </head>
+  <body>
+    <!-- ==================== Header ==================== -->
+    <header class="site-header">
+      <div class="container site-header__inner">
+        <a class="site-header__brand" href="#top" aria-label="Explores accueil">
+          <span class="site-header__brand-mark" aria-hidden="true">🧭</span>
+          <span>Explores</span>
+        </a>
+        <nav class="site-nav" aria-label="Menu principal">
+          <a href="#about">Atouts</a>
+          <a href="#how">Comment jouer</a>
+          <a href="#awards">Distinctions</a>
+          <a href="#faq">FAQ</a>
+          <a href="#contact">Contact</a>
+        </nav>
+        <a class="btn site-header__cta" href="#download" aria-label="Télécharger">
+          <svg class="site-header__cta-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>
+          <span class="site-header__cta-label">Télécharger</span>
+        </a>
+        <button class="menu-btn" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Ouvrir le menu">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+        </button>
+      </div>
+      <div id="mobile-menu" data-open="false">
+        <a href="#about">Atouts</a>
+        <a href="#how">Comment jouer</a>
+        <a href="#awards">Distinctions</a>
+        <a href="#faq">FAQ</a>
+        <a href="#contact">Contact</a>
+        <a href="/fr/privacy-policy/">Politique de confidentialité</a>
+        <div class="mobile-menu__lang" aria-label="Langue / Language">
+          <a href="/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/" hreflang="en" lang="en">English</a>
+          <a href="/zh/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/" hreflang="fr" lang="fr" class="is-current" aria-current="true">Français</a>
+          <a href="/it/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/" hreflang="es" lang="es">Español</a>
+          <a href="/th/" hreflang="th" lang="th">ไทย</a>
+        </div>
+      </div>
+    </header>
+
+    <!-- ==================== Hero ==================== -->
+    <section class="hero" id="top">
+      <div class="container hero__inner">
+        <div>
+          <span class="hero__eyebrow">🧭 Jeu d'exploration urbaine</span>
+          <h1 class="hero__title">Transformez la promenade en <em>aventure</em>.</h1>
+          <p class="hero__sub">
+            Guidé par des photos, partez à pied vers des lieux inconnus.<br />
+            Environ 15 minutes par partie. Un jeu de balade urbaine gratuit, sans achats intégrés.
+          </p>
+          <div class="hero__cta">
+            <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="Télécharger dans l'App Store">
+              <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/fr-fr?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
+            </a>
+            <a class="btn btn--secondary" href="/fr/tester-android">Android (recherche de testeurs)</a>
+          </div>
+          <p class="hero__note">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>
+            Gratuit ／ Sans achats intégrés ／ Sans publicité
+          </p>
+        </div>
+        <div class="hero__visual">
+          <img src="/assets/img/game-desc.jpg" alt="Aperçu d'une partie d'Explores" width="1200" height="676" />
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Empathy ==================== -->
+    <section class="section section--alt" id="about">
+      <div class="container">
+        <h2 class="section__title">Vos promenades vous lassent ?</h2>
+        <p class="section__lead">On veut marcher pour bouger un peu, mais le même trajet chaque jour, ça ne tient pas.<br />Avec « une marche qui a un but », ça pourrait durer un peu plus longtemps.</p>
+        <div class="card-grid">
+          <div class="empathy-card">
+            <div class="empathy-card__icon" aria-hidden="true">🛣️</div>
+            <h3>Toujours le même chemin</h3>
+            <p>De la maison à la gare, aller-retour. On finit par marcher sans même regarder le paysage.</p>
+          </div>
+          <div class="empathy-card">
+            <div class="empathy-card__icon" aria-hidden="true">📉</div>
+            <h3>Impossible d'en faire une habitude</h3>
+            <p>On se dit « allez, je marche », et trois jours plus tard, c'est déjà oublié.</p>
+          </div>
+          <div class="empathy-card">
+            <div class="empathy-card__icon" aria-hidden="true">🤔</div>
+            <h3>Aucune raison de marcher</h3>
+            <p>Marcher juste pour le sport, ça ne donne pas vraiment envie de continuer.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Value ==================== -->
+    <section class="section">
+      <div class="container">
+        <h2 class="section__title">Avec Explores,<br />la promenade devient une aventure.</h2>
+        <p class="section__lead">Pour seul indice, une photo, et un lieu inconnu à rejoindre.<br />Une destination différente à chaque fois. Une partie en 15 minutes. La voilà, votre raison de marcher.</p>
+        <div class="card-grid">
+          <div class="value-card">
+            <div class="value-card__badge">01</div>
+            <h3>Une destination différente à chaque fois</h3>
+            <p>Selon la durée choisie, une destination est tirée au sort à chaque partie. Impossible de se lasser des mêmes endroits.</p>
+          </div>
+          <div class="value-card">
+            <div class="value-card__badge">02</div>
+            <h3>Le frisson de l'aventure grâce aux photos</h3>
+            <p>Pas de carte : vous marchez en vous fiant aux photos des environs de la destination. « Ce bâtiment, je l'ai déjà vu quelque part… » : l'aventure commence là.</p>
+          </div>
+          <div class="value-card">
+            <div class="value-card__badge">03</div>
+            <h3>Une partie en 15 minutes</h3>
+            <p>Sur le chemin du retour, pendant une pause, lors d'une balade le week-end. Assez léger pour commencer quand on veut et s'arrêter quand on veut.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== How ==================== -->
+    <section class="section section--surface" id="how">
+      <div class="container">
+        <h2 class="section__title">Comment jouer, en 3 étapes</h2>
+        <p class="section__lead">30 secondes entre l'ouverture de l'appli et le départ dans la rue.</p>
+        <div class="steps">
+          <div class="step">
+            <div class="step__num">1</div>
+            <img class="step__img" src="/assets/img/game-play0.png" alt="Écran de sélection de la durée" loading="lazy" />
+            <h3>Choisissez votre durée</h3>
+            <p>Sélectionnez le temps que vous voulez marcher. « 15 min », « 30 min »… selon votre humeur du moment.</p>
+          </div>
+          <div class="step">
+            <div class="step__num">2</div>
+            <img class="step__img" src="/assets/img/game-play1.png" alt="Écran de vérification des photos et de la carte des environs de la destination" loading="lazy" />
+            <h3>Mémorisez la destination</h3>
+            <p>Avant le départ, observez bien les photos et la carte des environs de la destination. Une fois la partie lancée, tout disparaît.</p>
+          </div>
+          <div class="step">
+            <div class="step__num">3</div>
+            <img class="step__img" src="/assets/img/game-play2.png" alt="Écran de jeu pendant l'exploration" loading="lazy" />
+            <h3>Marchez de mémoire</h3>
+            <p>Avec pour seuls repères le temps restant et la distance, rejoignez la destination à pied. « Ça y est, c'est le paysage de la photo ! »</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Video ==================== -->
+    <section class="section">
+      <div class="container">
+        <h2 class="section__title">Explores en vidéo</h2>
+        <p class="section__lead">Découvrez de vraies parties et la balade urbaine en action.</p>
+        <div class="video-wrap">
+          <iframe src="https://www.youtube.com/embed/ldIJdk3zwHY?si=jwntDJV8pnRAHKio" title="Vidéo de présentation : comment jouer à Explores" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Awards ==================== -->
+    <section class="section section--alt" id="awards">
+      <div class="container">
+        <h2 class="section__title">Nos distinctions</h2>
+        <p class="section__lead">Un palmarès de concours bâti depuis nos années étudiantes.</p>
+        <div class="awards">
+          <article class="award">
+            <img src="/assets/img/award-gikuhaku.jpg" alt="Prix des entreprises au Gikuhaku" loading="lazy" />
+            <div class="award__body">
+              <span class="award__tag">Prix des entreprises</span>
+              <h3>Gikuhaku</h3>
+              <p>Au Gikuhaku organisé par Supporterz, Explores a remporté le Prix des entreprises.</p>
+              <a class="award__link" href="https://x.com/geek_pjt/status/1789225529109057540" target="_blank" rel="noopener noreferrer">Voir la publication →</a>
+            </div>
+          </article>
+          <article class="award">
+            <img src="/assets/img/award-wakayama.jpg" alt="Grand Prix au Concours de programmation et d'innovation de Wakayama" loading="lazy" />
+            <div class="award__body">
+              <span class="award__tag">Grand Prix</span>
+              <h3>Concours de programmation et d'innovation de Wakayama</h3>
+              <p>Grand Prix décerné pour un projet d'application mobile résolvant des défis locaux de Wakayama.</p>
+              <a class="award__link" href="https://wakayama-innovation-lab.relic.co.jp/" target="_blank" rel="noopener noreferrer">Voir les infos de l'organisateur →</a>
+            </div>
+          </article>
+          <article class="award">
+            <img src="/assets/img/award-iizuka.jpg" alt="Prix du maire au Concours e-ZUKA des applis intelligentes 2023" loading="lazy" />
+            <div class="award__body">
+              <span class="award__tag">Prix du maire + Prix des entreprises</span>
+              <h3>Concours e-ZUKA des applis intelligentes 2023</h3>
+              <p>Au concours organisé par la ville d'Iizuka (préfecture de Fukuoka), double récompense : Prix du maire d'Iizuka et Prix des entreprises.</p>
+              <a class="award__link" href="http://e-zuka.info/2023/resurt.html" target="_blank" rel="noopener noreferrer">Voir les résultats →</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Members ==================== -->
+    <section class="section" id="members">
+      <div class="container">
+        <h2 class="section__title">L'équipe de développement</h2>
+        <p class="section__lead">Une équipe de quatre personnes qui croit dur comme fer en « transformer la promenade en aventure ».</p>
+        <div class="members">
+          <div class="member">
+            <img src="/assets/img/member-akamatsu.png" alt="Taiki Akamatsu" loading="lazy" width="96" height="96" />
+            <h3>Taiki Akamatsu</h3>
+            <p>Fondateur / Ingénieur</p>
+            <div class="member__links">
+              <a href="https://www.wantedly.com/id/akamatsu_taiki" target="_blank" rel="noopener noreferrer" aria-label="Profil Wantedly">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3a14 14 0 010 18M12 3a14 14 0 000 18"/></svg>
+              </a>
+              <a href="https://github.com/Taiki-sub" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+              </a>
+            </div>
+          </div>
+          <div class="member">
+            <img src="/assets/img/member-chang.png" alt="Chang Ju-young" loading="lazy" width="96" height="96" />
+            <h3>Chang Ju-young</h3>
+            <p>Designer</p>
+          </div>
+          <div class="member">
+            <img src="/assets/img/siteTop4.jpg" alt="Kento Kusumoto" loading="lazy" width="96" height="96" />
+            <h3>Kento Kusumoto</h3>
+            <p>Designer</p>
+          </div>
+          <div class="member">
+            <img src="/assets/img/member-hayashi.png" alt="Shinichiro Hayashi" loading="lazy" width="96" height="96" />
+            <h3>Shinichiro Hayashi</h3>
+            <p>Ingénieur</p>
+            <div class="member__links">
+              <a href="https://www.github.com/hashin2425" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== FAQ ==================== -->
+    <section class="section section--surface" id="faq">
+      <div class="container">
+        <h2 class="section__title">Questions fréquentes</h2>
+        <p class="section__lead">Voici les points qui peuvent vous interroger avant de jouer.</p>
+        <div class="faq">
+          <details>
+            <summary>C'est vraiment gratuit ? Y a-t-il des achats intégrés ?</summary>
+            <p>C'est entièrement gratuit. Pas de gacha, pas d'abonnement, aucun achat intégré d'aucune sorte. Et pour l'instant, aucune publicité non plus.</p>
+          </details>
+          <details>
+            <summary>Combien de temps dure une partie ?</summary>
+            <p>Vous choisissez parmi 15, 20 ou 30 minutes, selon votre humeur du moment. Que vous ayez un court créneau libre ou envie de bien marcher le week-end, les deux fonctionnent.</p>
+          </details>
+          <details>
+            <summary>Où peut-on jouer ?</summary>
+            <p>En ville, vous pouvez en profiter à peu près partout. À partir de votre position GPS, une destination accessible à pied depuis votre point de départ est générée automatiquement.</p>
+          </details>
+          <details>
+            <summary>Quelle est la consommation de données et de batterie ?</summary>
+            <p>Comme la localisation est captée en continu, la batterie se vide plus vite lors des parties longues. La consommation de données concerne surtout l'affichage de la carte et reste raisonnable.</p>
+          </details>
+          <details>
+            <summary>Quelles précautions pour jouer en toute sécurité ?</summary>
+            <p>Soyez extrêmement prudent : ne manipulez pas votre téléphone en marchant. Arrêtez-vous avant les passages piétons, évitez les rues sombres et les zones désertes : respectez toujours les règles de base de sécurité d'une promenade.</p>
+          </details>
+          <details>
+            <summary>Existe-t-il une version Android ?</summary>
+            <p>Nous recherchons actuellement des testeurs en vue de la publication sur Google Play. Vous pouvez vous inscrire comme testeur depuis <a href="/fr/tester-android">cette page</a>.</p>
+          </details>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Final CTA ==================== -->
+    <section class="section cta-section" id="download">
+      <div class="container container--narrow">
+        <h2>Allez, transformez la promenade en aventure.</h2>
+        <p>Téléchargez l'appli dès maintenant et faites le premier pas vers l'inconnu.</p>
+        <div class="hero__cta" style="justify-content: center;">
+          <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="Télécharger dans l'App Store">
+            <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/fr-fr?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
+          </a>
+          <a class="btn" href="/fr/tester-android" style="background:#fff;">Android (recherche de testeurs)</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Contact ==================== -->
+    <section class="section" id="contact">
+      <div class="container">
+        <h2 class="section__title">Contact</h2>
+        <p class="section__lead">Signalement de bug, retours, projets de collaboration… n'hésitez pas à nous écrire.</p>
+        <div class="contact-card">
+          <p>Contactez-nous par e-mail via le bouton ci-dessous.</p>
+          <a class="btn btn--lg" href="mailto:akmatsutaiki@gmail.com?subject=%E3%80%90%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%A9%E3%83%BC%E3%82%BA%E3%80%91%E3%81%8A%E5%95%8F%E3%81%84%E5%90%88%E3%82%8F%E3%81%9B">
+            Nous contacter par e-mail
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Footer ==================== -->
+    <footer class="site-footer">
+      <div class="container">
+        <div class="site-footer__grid">
+          <div>
+            <div class="site-footer__brand">Explores</div>
+            <p class="site-footer__brand-line">Le jeu de balade urbaine qui transforme la promenade en aventure.<br />by Prokonjo</p>
+          </div>
+          <div class="site-footer__col">
+            <h4>Site</h4>
+            <ul>
+              <li><a href="#about">Atouts</a></li>
+              <li><a href="#how">Comment jouer</a></li>
+              <li><a href="#awards">Distinctions</a></li>
+              <li><a href="#faq">FAQ</a></li>
+            </ul>
+          </div>
+          <div class="site-footer__col">
+            <h4>Informations</h4>
+            <ul>
+              <li><a href="/fr/privacy-policy/">Politique de confidentialité</a></li>
+              <li><a href="#contact">Contact</a></li>
+              <li><a href="/fr/tester-android">Testeur Android</a></li>
+            </ul>
+          </div>
+        </div>
+        <nav class="lang-switch" aria-label="Langue / Language">
+          <span class="lang-switch__label">Langue</span>
+          <a href="/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/" hreflang="en" lang="en">English</a>
+          <a href="/zh/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/" hreflang="fr" lang="fr" class="is-current" aria-current="true">Français</a>
+          <a href="/it/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/" hreflang="es" lang="es">Español</a>
+          <a href="/th/" hreflang="th" lang="th">ไทย</a>
+        </nav>
+        <div class="site-footer__bottom">
+          <span>© 2024-2026 Prokonjo. All rights reserved.</span>
+          <div class="site-footer__social">
+            <a href="https://github.com/prokonjo-team" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+              <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      // Mobile menu toggle
+      (function() {
+        var btn = document.querySelector('.menu-btn');
+        var menu = document.getElementById('mobile-menu');
+        if (!btn || !menu) return;
+        btn.addEventListener('click', function() {
+          var open = menu.dataset.open === 'true';
+          menu.dataset.open = open ? 'false' : 'true';
+          btn.setAttribute('aria-expanded', String(!open));
+        });
+        // Close on link tap
+        menu.querySelectorAll('a').forEach(function(a) {
+          a.addEventListener('click', function() {
+            menu.dataset.open = 'false';
+            btn.setAttribute('aria-expanded', 'false');
+          });
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/fr/privacy-policy/index.html
+++ b/fr/privacy-policy/index.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>Politique de confidentialité｜Explores</title>
+    <meta name="description" content="Politique de confidentialité d'Explores. Traitement des données de localisation et durée de conservation des données." />
+    <meta name="theme-color" content="#FACD00" />
+    <meta name="robots" content="noindex" />
+    <link rel="canonical" href="https://prokonjo.com/fr/privacy-policy/" />
+    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/privacy-policy/" />
+    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/privacy-policy/" />
+    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/privacy-policy/" />
+    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/privacy-policy/" />
+    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/privacy-policy/" />
+    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/privacy-policy/" />
+    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/privacy-policy/" />
+    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/privacy-policy/" />
+    <link rel="icon" type="image/png" href="/assets/favicon.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/css/styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-P3YYZEG46Z');
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container site-header__inner">
+        <a class="site-header__brand" href="/fr/" aria-label="Accueil Explores">
+          <span class="site-header__brand-mark" aria-hidden="true">🧭</span>
+          <span>Explores</span>
+        </a>
+        <nav class="site-nav" aria-label="Menu principal">
+          <a href="/fr/#about">Fonctionnalités</a>
+          <a href="/fr/#how">Comment jouer</a>
+          <a href="/fr/#awards">Distinctions</a>
+          <a href="/fr/#faq">FAQ</a>
+          <a href="/fr/#contact">Contact</a>
+        </nav>
+        <a class="btn site-header__cta" href="/fr/#download" aria-label="Télécharger">
+          <svg class="site-header__cta-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>
+          <span class="site-header__cta-label">Télécharger</span>
+        </a>
+        <button class="menu-btn" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Ouvrir le menu">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+        </button>
+      </div>
+      <div id="mobile-menu" data-open="false">
+        <a href="/fr/#about">Fonctionnalités</a>
+        <a href="/fr/#how">Comment jouer</a>
+        <a href="/fr/#awards">Distinctions</a>
+        <a href="/fr/#faq">FAQ</a>
+        <a href="/fr/#contact">Contact</a>
+        <a href="/fr/privacy-policy/">Politique de confidentialité</a>
+        <div class="mobile-menu__lang" aria-label="Langue / Language">
+          <a href="/privacy-policy/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/privacy-policy/" hreflang="en" lang="en">English</a>
+          <a href="/zh/privacy-policy/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/privacy-policy/" hreflang="fr" lang="fr" class="is-current" aria-current="true">Français</a>
+          <a href="/it/privacy-policy/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/privacy-policy/" hreflang="es" lang="es">Español</a>
+          <a href="/th/privacy-policy/" hreflang="th" lang="th">ไทย</a>
+        </div>
+      </div>
+    </header>
+
+    <section class="page-header">
+      <div class="container">
+        <h1>Politique de confidentialité</h1>
+        <p class="page-header__lead">À propos des informations traitées par Explores et de leurs finalités d'utilisation.</p>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <article class="prose">
+          <p>La présente politique de confidentialité s'applique à l'application mobile « Explores » (ci-après « l'Application ») fournie gratuitement par Taiki Akamatsu (ci-après le « Fournisseur de services »). Ce service est fourni sur la base d'une utilisation « en l'état ».</p>
+
+          <h2>Informations collectées et finalités d'utilisation</h2>
+          <p>L'Application peut collecter les informations suivantes lors de son téléchargement et de son utilisation.</p>
+          <ul>
+            <li>L'adresse IP de l'appareil</li>
+            <li>Les pages consultées au sein de l'Application, la date et l'heure de visite ainsi que la durée de consultation</li>
+            <li>La durée d'utilisation de l'Application</li>
+            <li>Le système d'exploitation de l'appareil mobile utilisé</li>
+          </ul>
+
+          <p>L'Application collecte les données de localisation de l'appareil. Ces données de localisation sont utilisées pour déterminer la position géographique approximative et sont exploitées aux fins suivantes.</p>
+          <ul>
+            <li><strong>Services de localisation</strong> : fournir des contenus personnalisés, des recommandations pertinentes et des fonctionnalités basées sur la localisation</li>
+            <li><strong>Analyse et amélioration</strong> : analyser le comportement des utilisateurs et améliorer les performances globales de l'Application à partir de données de localisation agrégées et anonymisées</li>
+            <li><strong>Services tiers</strong> : transmettre des données de localisation anonymisées à des services externes qui contribuent à l'amélioration de l'Application ou à l'optimisation des contenus proposés</li>
+          </ul>
+
+          <p>Le Fournisseur de services peut utiliser les informations collectées afin de vous contacter (avis importants, notifications nécessaires, communications marketing, etc.). Par ailleurs, pour vous offrir une meilleure expérience, il peut vous demander de fournir certaines informations permettant de vous identifier ; ces informations seront utilisées et conservées conformément à la présente politique.</p>
+
+          <h2>Communication d'informations à des tiers</h2>
+          <p>Seules des données agrégées et anonymisées sont transmises régulièrement aux services externes. Le Fournisseur de services peut partager des informations avec des tiers selon les modalités décrites dans la présente politique.</p>
+
+          <p>L'Application a recours à des services tiers disposant de leur propre politique de confidentialité. Veuillez consulter ci-dessous la politique de confidentialité des services tiers utilisés.</p>
+          <ul>
+            <li><a href="https://www.google.com/policies/privacy/" target="_blank" rel="noopener noreferrer">Google Play Services</a></li>
+          </ul>
+
+          <p>Le Fournisseur de services peut divulguer les informations fournies par l'utilisateur et les informations collectées automatiquement dans l'un des cas suivants.</p>
+          <ul>
+            <li>Lorsque la loi l'exige, notamment pour répondre à une assignation à comparaître ou à une procédure judiciaire équivalente</li>
+            <li>Lorsqu'il l'estime de bonne foi nécessaire pour protéger ses droits, garantir la sécurité des utilisateurs ou de tiers, enquêter sur des fraudes ou répondre à une demande des autorités</li>
+            <li>Lorsqu'il s'agit de prestataires de services de confiance agissant pour son compte, qui se sont engagés à ne pas utiliser ces informations de manière indépendante et à respecter la présente politique</li>
+          </ul>
+
+          <h2>À propos du retrait du consentement</h2>
+          <p>Vous pouvez interrompre toute collecte d'informations en désinstallant l'Application. Veuillez utiliser la procédure de désinstallation standard de votre appareil ou de la boutique d'applications.</p>
+
+          <h2>Durée de conservation des données</h2>
+          <p>Le Fournisseur de services conserve les données fournies par l'utilisateur pendant toute la durée d'utilisation de l'Application ainsi que pour une période jugée raisonnable. Si vous souhaitez la suppression des données que vous avez fournies via l'Application, veuillez contacter <a href="mailto:akmatsutaiki@gmail.com">akmatsutaiki@gmail.com</a>. Nous y donnerons suite dans un délai raisonnable.</p>
+
+          <h2>À propos de l'utilisation par les enfants</h2>
+          <p>Le Fournisseur de services ne collecte pas intentionnellement de données auprès d'enfants de moins de 13 ans et ne mène pas d'actions marketing à leur égard par l'intermédiaire de l'Application.</p>
+          <p>L'Application ne s'adresse pas aux personnes de moins de 13 ans. S'il s'avérait que des informations personnelles ont été fournies par un enfant de moins de 13 ans, elles seraient immédiatement supprimées de nos serveurs. Si vous êtes parent ou tuteur et que vous constatez que votre enfant a fourni des informations personnelles, veuillez contacter <a href="mailto:akmatsutaiki@gmail.com">akmatsutaiki@gmail.com</a>.</p>
+
+          <h2>Sécurité</h2>
+          <p>Le Fournisseur de services s'efforce de préserver la confidentialité de vos informations. Il met en œuvre des mesures de sécurité physiques, électroniques et procédurales afin de protéger les données traitées et conservées.</p>
+
+          <h2>Modifications de la présente politique</h2>
+          <p>La présente politique de confidentialité peut être mise à jour à tout moment, selon les besoins. Le Fournisseur de services vous informera des modifications en mettant à jour la présente page. Une utilisation continue vaut acceptation de l'ensemble des modifications ; veuillez donc la consulter régulièrement.</p>
+
+          <p>Date d'entrée en vigueur de la présente politique de confidentialité : <strong>2024-05-06</strong></p>
+
+          <h2>À propos du consentement</h2>
+          <p>L'utilisation de l'Application vaut acceptation du traitement de vos informations conformément à la présente politique de confidentialité.</p>
+
+          <h2>Contact</h2>
+          <p>Pour toute question relative à la confidentialité lors de l'utilisation de l'Application ou concernant la présente politique, veuillez nous contacter par e-mail à l'adresse <a href="mailto:akmatsutaiki@gmail.com">akmatsutaiki@gmail.com</a>.</p>
+
+          <hr />
+          <p style="font-size: 0.86rem; color: var(--c-text-muted);">La présente politique a été rédigée à l'aide de <a href="https://app-privacy-policy-generator.nisrulz.com/" target="_blank" rel="noopener noreferrer">App Privacy Policy Generator</a>.</p>
+        </article>
+      </div>
+    </section>
+
+    <footer class="site-footer">
+      <div class="container">
+        <div class="site-footer__grid">
+          <div>
+            <div class="site-footer__brand">Explores</div>
+            <p class="site-footer__brand-line">Le jeu de balade urbaine qui transforme vos promenades en aventures.<br />by Prokonjo (prokonjo)</p>
+          </div>
+          <div class="site-footer__col">
+            <h4>Site</h4>
+            <ul>
+              <li><a href="/fr/#about">Fonctionnalités</a></li>
+              <li><a href="/fr/#how">Comment jouer</a></li>
+              <li><a href="/fr/#awards">Distinctions</a></li>
+              <li><a href="/fr/#faq">FAQ</a></li>
+            </ul>
+          </div>
+          <div class="site-footer__col">
+            <h4>Informations sur l'éditeur</h4>
+            <ul>
+              <li><a href="/fr/privacy-policy/">Politique de confidentialité</a></li>
+              <li><a href="/fr/#contact">Contact</a></li>
+              <li><a href="/fr/tester-android/">Testeur Android</a></li>
+            </ul>
+          </div>
+        </div>
+        <nav class="lang-switch" aria-label="Langue / Language">
+          <span class="lang-switch__label">Langue</span>
+          <a href="/privacy-policy/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/privacy-policy/" hreflang="en" lang="en">English</a>
+          <a href="/zh/privacy-policy/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/privacy-policy/" hreflang="fr" lang="fr" class="is-current" aria-current="true">Français</a>
+          <a href="/it/privacy-policy/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/privacy-policy/" hreflang="es" lang="es">Español</a>
+          <a href="/th/privacy-policy/" hreflang="th" lang="th">ไทย</a>
+        </nav>
+        <div class="site-footer__bottom">
+          <span>© 2024-2026 Prokonjo (prokonjo). All rights reserved.</span>
+          <div class="site-footer__social">
+            <a href="https://github.com/prokonjo-team" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+              <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      (function() {
+        var btn = document.querySelector('.menu-btn');
+        var menu = document.getElementById('mobile-menu');
+        if (!btn || !menu) return;
+        btn.addEventListener('click', function() {
+          var open = menu.dataset.open === 'true';
+          menu.dataset.open = open ? 'false' : 'true';
+          btn.setAttribute('aria-expanded', String(!open));
+        });
+        menu.querySelectorAll('a').forEach(function(a) {
+          a.addEventListener('click', function() {
+            menu.dataset.open = 'false';
+            btn.setAttribute('aria-expanded', 'false');
+          });
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/fr/tester-android/index.html
+++ b/fr/tester-android/index.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>Recherche de testeurs Android｜Explores</title>
+    <meta name="description" content="Page de recrutement de testeurs Android pour Explores. Inscrivez-vous au Google Groups, installez l'application, lancez-la : trois étapes seulement." />
+    <meta name="theme-color" content="#FACD00" />
+    <meta name="robots" content="noindex" />
+    <link rel="canonical" href="https://prokonjo.com/fr/tester-android/" />
+    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/tester-android/" />
+    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/tester-android/" />
+    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/tester-android/" />
+    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/tester-android/" />
+    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/tester-android/" />
+    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/tester-android/" />
+    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/tester-android/" />
+    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/tester-android/" />
+    <link rel="icon" type="image/png" href="/assets/favicon.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/css/styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-P3YYZEG46Z');
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container site-header__inner">
+        <a class="site-header__brand" href="/fr/" aria-label="Accueil Explores">
+          <span class="site-header__brand-mark" aria-hidden="true">🧭</span>
+          <span>Explores</span>
+        </a>
+        <nav class="site-nav" aria-label="Menu principal">
+          <a href="/fr/#about">Caractéristiques</a>
+          <a href="/fr/#how">Comment jouer</a>
+          <a href="/fr/#awards">Récompenses</a>
+          <a href="/fr/#faq">FAQ</a>
+          <a href="/fr/#contact">Contact</a>
+        </nav>
+        <a class="btn site-header__cta" href="/fr/#download" aria-label="Télécharger">
+          <svg class="site-header__cta-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>
+          <span class="site-header__cta-label">Télécharger</span>
+        </a>
+        <button class="menu-btn" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Ouvrir le menu">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+        </button>
+      </div>
+      <div id="mobile-menu" data-open="false">
+        <a href="/fr/#about">Caractéristiques</a>
+        <a href="/fr/#how">Comment jouer</a>
+        <a href="/fr/#awards">Récompenses</a>
+        <a href="/fr/#faq">FAQ</a>
+        <a href="/fr/#contact">Contact</a>
+        <a href="/fr/privacy-policy/">Politique de confidentialité</a>
+        <div class="mobile-menu__lang" aria-label="Langue / Language">
+          <a href="/tester-android/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/tester-android/" hreflang="en" lang="en">English</a>
+          <a href="/zh/tester-android/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/tester-android/" hreflang="fr" lang="fr" class="is-current" aria-current="true">Français</a>
+          <a href="/it/tester-android/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/tester-android/" hreflang="es" lang="es">Español</a>
+          <a href="/th/tester-android/" hreflang="th" lang="th">ไทย</a>
+        </div>
+      </div>
+    </header>
+
+    <section class="page-header">
+      <div class="container">
+        <h1>Recherche de testeurs Android</h1>
+        <p class="page-header__lead">En vue de la sortie sur Google Play, nous recherchons des personnes prêtes à jouer en avant-première à Explores sur Android. Trois étapes suffisent pour participer !</p>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container container--narrow">
+        <div class="callout" style="margin-bottom: 2.5rem;">
+          <span class="callout__icon" aria-hidden="true">💡</span>
+          <div class="callout__body">
+            <strong>Ce que nous vous demandons en tant que testeur</strong>
+            <p>Trois choses : installer l'application Android (obligatoire), la lancer (obligatoire) et répondre à un questionnaire (facultatif).</p>
+          </div>
+        </div>
+
+        <div class="tester-step">
+          <div class="tester-step__num">1</div>
+          <div class="tester-step__body">
+            <h3>S'inscrire au Google Groups</h3>
+            <p>Rejoignez le Google Groups via le lien ci-dessous. Sans appartenir au Google Groups dédié aux testeurs, l'application ne s'affichera pas sur Google Play.</p>
+            <a class="btn" href="https://groups.google.com/search?q=explores_tester&inOrg=false" target="_blank" rel="noopener noreferrer">S'inscrire au Google Groups</a>
+            <div class="tester-step__images">
+              <img src="/tester-android/imgs/1.png" alt="Procédure d'inscription au Google Groups 1" loading="lazy" />
+              <img src="/tester-android/imgs/2.png" alt="Procédure d'inscription au Google Groups 2" loading="lazy" />
+            </div>
+          </div>
+        </div>
+
+        <div class="tester-step">
+          <div class="tester-step__num">2</div>
+          <div class="tester-step__body">
+            <h3>Installer l'application</h3>
+            <p>Une fois votre inscription au Google Groups prise en compte, installez l'application sur Google Play via le lien ci-dessous.</p>
+            <a class="btn" href="https://play.google.com/store/apps/details?id=com.prokonjo.explores" target="_blank" rel="noopener noreferrer">Installer sur Google Play</a>
+            <p style="margin-top: 1rem; font-size: 0.92rem;">Si le message « L'URL demandée est introuvable sur ce serveur. » s'affiche, il est possible que votre inscription au Google Groups ne soit pas encore prise en compte. Patientez un instant, puis réessayez.</p>
+          </div>
+        </div>
+
+        <div class="tester-step">
+          <div class="tester-step__num">3</div>
+          <div class="tester-step__body">
+            <h3>Lancer l'application</h3>
+            <p>Après l'installation, lancez l'application une fois pour finaliser votre inscription en tant que testeur.</p>
+            <div class="callout">
+              <span class="callout__icon" aria-hidden="true">⚠️</span>
+              <div class="callout__body">
+                <strong>Une demande</strong>
+                <p>Une fois l'application installée, merci de ne pas la supprimer. La désinstaller vous retire de la liste des testeurs.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="tester-step">
+          <div class="tester-step__num">+</div>
+          <div class="tester-step__body">
+            <h3>(Facultatif) Aidez-nous en répondant au questionnaire</h3>
+            <p>Vos retours sur l'expérience d'utilisation nous aident à améliorer l'application.</p>
+            <a class="btn btn--secondary" href="https://docs.google.com/forms/d/1sWQDp1t_8PnzxENLO9BHw-IYn2yrNgumjZMQWQWam8I" target="_blank" rel="noopener noreferrer">Répondre au questionnaire</a>
+          </div>
+        </div>
+
+        <div style="text-align: center; margin-top: 3rem;">
+          <a class="btn btn--ghost" href="/fr/">Retour à l'accueil</a>
+        </div>
+      </div>
+    </section>
+
+    <footer class="site-footer">
+      <div class="container">
+        <div class="site-footer__grid">
+          <div>
+            <div class="site-footer__brand">Explores</div>
+            <p class="site-footer__brand-line">Le jeu de balade urbaine qui transforme la promenade en aventure.<br />par Prokonjo</p>
+          </div>
+          <div class="site-footer__col">
+            <h4>Site</h4>
+            <ul>
+              <li><a href="/fr/#about">Caractéristiques</a></li>
+              <li><a href="/fr/#how">Comment jouer</a></li>
+              <li><a href="/fr/#awards">Récompenses</a></li>
+              <li><a href="/fr/#faq">FAQ</a></li>
+            </ul>
+          </div>
+          <div class="site-footer__col">
+            <h4>Informations</h4>
+            <ul>
+              <li><a href="/fr/privacy-policy/">Politique de confidentialité</a></li>
+              <li><a href="/fr/#contact">Contact</a></li>
+              <li><a href="/fr/tester-android/">Testeur Android</a></li>
+            </ul>
+          </div>
+        </div>
+        <nav class="lang-switch" aria-label="Langue / Language">
+          <span class="lang-switch__label">Langue</span>
+          <a href="/tester-android/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/tester-android/" hreflang="en" lang="en">English</a>
+          <a href="/zh/tester-android/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/tester-android/" hreflang="fr" lang="fr" class="is-current" aria-current="true">Français</a>
+          <a href="/it/tester-android/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/tester-android/" hreflang="es" lang="es">Español</a>
+          <a href="/th/tester-android/" hreflang="th" lang="th">ไทย</a>
+        </nav>
+        <div class="site-footer__bottom">
+          <span>© 2024-2026 Prokonjo. All rights reserved.</span>
+          <div class="site-footer__social">
+            <a href="https://github.com/prokonjo-team" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+              <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      (function() {
+        var btn = document.querySelector('.menu-btn');
+        var menu = document.getElementById('mobile-menu');
+        if (!btn || !menu) return;
+        btn.addEventListener('click', function() {
+          var open = menu.dataset.open === 'true';
+          menu.dataset.open = open ? 'false' : 'true';
+          btn.setAttribute('aria-expanded', String(!open));
+        });
+        menu.querySelectorAll('a').forEach(function(a) {
+          a.addEventListener('click', function() {
+            menu.dataset.open = 'false';
+            btn.setAttribute('aria-expanded', 'false');
+          });
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,16 @@
     <meta name="theme-color" content="#FACD00" />
     <link rel="canonical" href="https://prokonjo.com/" />
 
+    <!-- hreflang alternates -->
+    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/" />
+    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/" />
+    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/" />
+    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/" />
+    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/" />
+    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/" />
+    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/" />
+    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/" />
+
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content="エクスプロラーズ" />
@@ -84,8 +94,9 @@
           <a href="#faq">FAQ</a>
           <a href="#contact">お問い合わせ</a>
         </nav>
-        <a class="btn site-header__cta" href="#download">
-          ダウンロード
+        <a class="btn site-header__cta" href="#download" aria-label="ダウンロード">
+          <svg class="site-header__cta-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>
+          <span class="site-header__cta-label">ダウンロード</span>
         </a>
         <button class="menu-btn" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="メニューを開く">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
@@ -98,6 +109,15 @@
         <a href="#faq">FAQ</a>
         <a href="#contact">お問い合わせ</a>
         <a href="/privacy-policy/">プライバシーポリシー</a>
+        <div class="mobile-menu__lang" aria-label="言語 / Language">
+          <a href="/" hreflang="ja" lang="ja" class="is-current" aria-current="true">日本語</a>
+          <a href="/en/" hreflang="en" lang="en">English</a>
+          <a href="/zh/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/" hreflang="es" lang="es">Español</a>
+          <a href="/th/" hreflang="th" lang="th">ไทย</a>
+        </div>
       </div>
     </header>
 
@@ -385,6 +405,16 @@
             </ul>
           </div>
         </div>
+        <nav class="lang-switch" aria-label="言語 / Language">
+          <span class="lang-switch__label">言語</span>
+          <a href="/" hreflang="ja" lang="ja" class="is-current" aria-current="true">日本語</a>
+          <a href="/en/" hreflang="en" lang="en">English</a>
+          <a href="/zh/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/" hreflang="es" lang="es">Español</a>
+          <a href="/th/" hreflang="th" lang="th">ไทย</a>
+        </nav>
         <div class="site-footer__bottom">
           <span>© 2024-2026 プロ根性 (prokonjo). All rights reserved.</span>
           <div class="site-footer__social">

--- a/it/index.html
+++ b/it/index.html
@@ -1,0 +1,450 @@
+<!DOCTYPE html>
+<html lang="it">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>Explores｜Il gioco di passeggiate urbane che trasforma la camminata in avventura</title>
+    <meta name="description" content="Explores, il gioco di passeggiate urbane che trasforma la tua camminata in un'avventura. Seguendo le foto come indizio, raggiungi a piedi luoghi che non conosci. Una partita dura circa 15 minuti, gratis e senza acquisti in-app." />
+    <meta name="author" content="Prokonjo" />
+    <meta name="theme-color" content="#FACD00" />
+    <link rel="canonical" href="https://prokonjo.com/it/" />
+
+    <!-- hreflang alternates -->
+    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/" />
+    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/" />
+    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/" />
+    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/" />
+    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/" />
+    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/" />
+    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/" />
+    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/" />
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Explores" />
+    <meta property="og:title" content="Explores｜Il gioco di passeggiate urbane che trasforma la camminata in avventura" />
+    <meta property="og:description" content="Il gioco di passeggiate urbane in cui, seguendo le foto come indizio, raggiungi a piedi luoghi che non conosci. Una partita dura circa 15 minuti, gratis e senza acquisti in-app." />
+    <meta property="og:url" content="https://prokonjo.com/it/" />
+    <meta property="og:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+    <meta property="og:image:type" content="image/jpeg" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:locale" content="it_IT" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Explores｜Il gioco di passeggiate urbane che trasforma la camminata in avventura" />
+    <meta name="twitter:description" content="Il gioco di passeggiate urbane in cui, seguendo le foto come indizio, raggiungi a piedi luoghi che non conosci. Una partita dura circa 15 minuti, gratis e senza acquisti in-app." />
+    <meta name="twitter:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" href="/assets/favicon.png" />
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+
+    <link rel="stylesheet" href="/css/styles.css" />
+
+    <!-- Structured data -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "MobileApplication",
+        "name": "Explores",
+        "description": "Il gioco di passeggiate urbane che trasforma la camminata in avventura. Seguendo le foto come indizio, raggiungi a piedi luoghi che non conosci: un'esperienza di esplorazione di circa 15 minuti a partita.",
+        "url": "https://prokonjo.com/",
+        "applicationCategory": "GameApplication",
+        "operatingSystem": "iOS",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "JPY"
+        },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Prokonjo",
+          "url": "https://prokonjo.com/"
+        }
+      }
+    </script>
+
+    <!-- Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-P3YYZEG46Z');
+    </script>
+  </head>
+  <body>
+    <!-- ==================== Header ==================== -->
+    <header class="site-header">
+      <div class="container site-header__inner">
+        <a class="site-header__brand" href="#top" aria-label="Explores home">
+          <span class="site-header__brand-mark" aria-hidden="true">🧭</span>
+          <span>Explores</span>
+        </a>
+        <nav class="site-nav" aria-label="Main menu">
+          <a href="#about">Caratteristiche</a>
+          <a href="#how">Come si gioca</a>
+          <a href="#awards">Riconoscimenti</a>
+          <a href="#faq">FAQ</a>
+          <a href="#contact">Contatti</a>
+        </nav>
+        <a class="btn site-header__cta" href="#download" aria-label="Scarica">
+          <svg class="site-header__cta-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>
+          <span class="site-header__cta-label">Scarica</span>
+        </a>
+        <button class="menu-btn" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+        </button>
+      </div>
+      <div id="mobile-menu" data-open="false">
+        <a href="#about">Caratteristiche</a>
+        <a href="#how">Come si gioca</a>
+        <a href="#awards">Riconoscimenti</a>
+        <a href="#faq">FAQ</a>
+        <a href="#contact">Contatti</a>
+        <a href="/it/privacy-policy/">Informativa sulla privacy</a>
+        <div class="mobile-menu__lang" aria-label="Lingua / Language">
+          <a href="/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/" hreflang="en" lang="en">English</a>
+          <a href="/zh/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/" hreflang="it" lang="it" class="is-current" aria-current="true">Italiano</a>
+          <a href="/es/" hreflang="es" lang="es">Español</a>
+          <a href="/th/" hreflang="th" lang="th">ไทย</a>
+        </div>
+      </div>
+    </header>
+
+    <!-- ==================== Hero ==================== -->
+    <section class="hero" id="top">
+      <div class="container hero__inner">
+        <div>
+          <span class="hero__eyebrow">🧭 Gioco di esplorazione urbana a piedi</span>
+          <h1 class="hero__title">Trasforma la passeggiata in <em>avventura</em>.</h1>
+          <p class="hero__sub">
+            Seguendo le foto come indizio, raggiungi a piedi luoghi che non conosci.<br />
+            Una partita dura circa 15 minuti. Un gioco di passeggiate urbane gratis e senza acquisti in-app.
+          </p>
+          <div class="hero__cta">
+            <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="Scarica sull'App Store">
+              <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/it-it?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
+            </a>
+            <a class="btn btn--secondary" href="/it/tester-android">Android (cerchiamo tester)</a>
+          </div>
+          <p class="hero__note">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>
+            Gratis ／ Senza acquisti in-app ／ Senza pubblicità
+          </p>
+        </div>
+        <div class="hero__visual">
+          <img src="/assets/img/game-desc.jpg" alt="Immagine di gioco di Explores" width="1200" height="676" />
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Empathy ==================== -->
+    <section class="section section--alt" id="about">
+      <div class="container">
+        <h2 class="section__title">Le tue passeggiate ti hanno stancato?</h2>
+        <p class="section__lead">Anche con le migliori intenzioni di muoverti, fare sempre lo stesso percorso diventa difficile da mantenere.<br />Con una camminata che ha uno scopo, forse riusciresti a continuare un po' più a lungo.</p>
+        <div class="card-grid">
+          <div class="empathy-card">
+            <div class="empathy-card__icon" aria-hidden="true">🛣️</div>
+            <h3>Sempre la stessa strada, che noia</h3>
+            <p>Casa-stazione e ritorno. Alla fine cammini senza nemmeno guardare il paesaggio.</p>
+          </div>
+          <div class="empathy-card">
+            <div class="empathy-card__icon" aria-hidden="true">📉</div>
+            <h3>Non diventa un'abitudine</h3>
+            <p>Decidi di camminare, ma dopo tre giorni te ne sei già dimenticato.</p>
+          </div>
+          <div class="empathy-card">
+            <div class="empathy-card__icon" aria-hidden="true">🤔</div>
+            <h3>Manca uno scopo per camminare</h3>
+            <p>Se è solo per fare moto, la motivazione non regge a lungo.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Value ==================== -->
+    <section class="section">
+      <div class="container">
+        <h2 class="section__title">Con Explores,<br />la passeggiata diventa avventura.</h2>
+        <p class="section__lead">Con una semplice foto come indizio, punti verso un luogo che non conosci.<br />Una meta diversa ogni volta. Tutto in 15 minuti. Ecco il tuo motivo per camminare.</p>
+        <div class="card-grid">
+          <div class="value-card">
+            <div class="value-card__badge">01</div>
+            <h3>Una meta diversa ogni volta</h3>
+            <p>In base al tempo che scegli, la destinazione viene sorteggiata di volta in volta. Niente più noia dello stesso posto.</p>
+          </div>
+          <div class="value-card">
+            <div class="value-card__badge">02</div>
+            <h3>L'avventura nasce dalle foto</h3>
+            <p>Niente mappa: ti orienti grazie alle foto dei dintorni della meta. "Quell'edificio... l'ho già visto da qualche parte" è l'inizio dell'avventura.</p>
+          </div>
+          <div class="value-card">
+            <div class="value-card__badge">03</div>
+            <h3>Tutto in 15 minuti</h3>
+            <p>Tornando dal lavoro, in pausa, durante una passeggiata nel weekend. Leggero al punto giusto: inizi quando vuoi e ti fermi quando vuoi.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== How ==================== -->
+    <section class="section section--surface" id="how">
+      <div class="container">
+        <h2 class="section__title">Come si gioca: in 3 passi</h2>
+        <p class="section__lead">Dall'apertura dell'app al primo passo in strada: 30 secondi.</p>
+        <div class="steps">
+          <div class="step">
+            <div class="step__num">1</div>
+            <img class="step__img" src="/assets/img/game-play0.png" alt="Schermata di selezione del tempo" loading="lazy" />
+            <h3>Scegli il tempo</h3>
+            <p>Seleziona quanto vuoi camminare. "15 minuti", "30 minuti"... a seconda dell'umore del momento.</p>
+          </div>
+          <div class="step">
+            <div class="step__num">2</div>
+            <img class="step__img" src="/assets/img/game-play1.png" alt="Schermata di verifica delle foto e della mappa dei dintorni della meta" loading="lazy" />
+            <h3>Memorizza la meta</h3>
+            <p>Prima di iniziare, osserva bene le foto e la mappa dei dintorni della meta. Una volta partito, spariscono.</p>
+          </div>
+          <div class="step">
+            <div class="step__num">3</div>
+            <img class="step__img" src="/assets/img/game-play2.png" alt="Schermata di gioco durante l'esplorazione" loading="lazy" />
+            <h3>Cammina affidandoti alla memoria</h3>
+            <p>Con solo il tempo rimasto e la distanza come riferimento, raggiungi la meta a piedi. "Ehi, è proprio il paesaggio di quella foto!"</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Video ==================== -->
+    <section class="section">
+      <div class="container">
+        <h2 class="section__title">Explores in video</h2>
+        <p class="section__lead">Guarda lo schermo di gioco reale e una passeggiata in azione.</p>
+        <div class="video-wrap">
+          <iframe src="https://www.youtube.com/embed/ldIJdk3zwHY?si=jwntDJV8pnRAHKio" title="Video di presentazione: come si gioca a Explores" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Awards ==================== -->
+    <section class="section section--alt" id="awards">
+      <div class="container">
+        <h2 class="section__title">Premi e riconoscimenti</h2>
+        <p class="section__lead">Risultati nei concorsi accumulati fin dagli anni dell'università.</p>
+        <div class="awards">
+          <article class="award">
+            <img src="/assets/img/award-gikuhaku.jpg" alt="Vincitore del Premio Aziende al Gikuhaku" loading="lazy" />
+            <div class="award__body">
+              <span class="award__tag">Premio Aziende</span>
+              <h3>Gikuhaku</h3>
+              <p>Al Gikuhaku organizzato da Supporterz, Explores ha vinto il Premio Aziende.</p>
+              <a class="award__link" href="https://x.com/geek_pjt/status/1789225529109057540" target="_blank" rel="noopener noreferrer">Vedi il post della premiazione →</a>
+            </div>
+          </article>
+          <article class="award">
+            <img src="/assets/img/award-wakayama.jpg" alt="Vincitore del Primo Premio al Wakayama Innovation Programming Contest" loading="lazy" />
+            <div class="award__body">
+              <span class="award__tag">Primo Premio</span>
+              <h3>Wakayama Innovation Programming Contest</h3>
+              <p>Primo premio per un progetto di app per smartphone pensato per risolvere problemi del territorio di Wakayama.</p>
+              <a class="award__link" href="https://wakayama-innovation-lab.relic.co.jp/" target="_blank" rel="noopener noreferrer">Vedi le info sull'organizzatore →</a>
+            </div>
+          </article>
+          <article class="award">
+            <img src="/assets/img/award-iizuka.jpg" alt="Vincitore del Premio del Sindaco all'e-ZUKA Smart App Contest 2023" loading="lazy" />
+            <div class="award__body">
+              <span class="award__tag">Premio del Sindaco + Premio Aziende</span>
+              <h3>e-ZUKA Smart App Contest 2023</h3>
+              <p>Al concorso organizzato dalla città di Iizuka (Fukuoka), doppio riconoscimento: Premio del Sindaco di Iizuka e Premio Aziende.</p>
+              <a class="award__link" href="http://e-zuka.info/2023/resurt.html" target="_blank" rel="noopener noreferrer">Vedi i risultati del concorso →</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Members ==================== -->
+    <section class="section" id="members">
+      <div class="container">
+        <h2 class="section__title">Il team di sviluppo</h2>
+        <p class="section__lead">Un team di quattro persone che lavora sul serio per "trasformare la passeggiata in avventura".</p>
+        <div class="members">
+          <div class="member">
+            <img src="/assets/img/member-akamatsu.png" alt="Taiki Akamatsu" loading="lazy" width="96" height="96" />
+            <h3>赤松汰輝</h3>
+            <p>Fondatore / Ingegnere</p>
+            <div class="member__links">
+              <a href="https://www.wantedly.com/id/akamatsu_taiki" target="_blank" rel="noopener noreferrer" aria-label="Profilo Wantedly">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3a14 14 0 010 18M12 3a14 14 0 000 18"/></svg>
+              </a>
+              <a href="https://github.com/Taiki-sub" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+              </a>
+            </div>
+          </div>
+          <div class="member">
+            <img src="/assets/img/member-chang.png" alt="張珠煐" loading="lazy" width="96" height="96" />
+            <h3>張珠煐</h3>
+            <p>Designer</p>
+          </div>
+          <div class="member">
+            <img src="/assets/img/siteTop4.jpg" alt="楠本健人" loading="lazy" width="96" height="96" />
+            <h3>楠本健人</h3>
+            <p>Designer</p>
+          </div>
+          <div class="member">
+            <img src="/assets/img/member-hayashi.png" alt="林慎一郎" loading="lazy" width="96" height="96" />
+            <h3>林慎一郎</h3>
+            <p>Ingegnere</p>
+            <div class="member__links">
+              <a href="https://www.github.com/hashin2425" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== FAQ ==================== -->
+    <section class="section section--surface" id="faq">
+      <div class="container">
+        <h2 class="section__title">Domande frequenti</h2>
+        <p class="section__lead">Abbiamo raccolto i dubbi più comuni prima di iniziare a giocare.</p>
+        <div class="faq">
+          <details>
+            <summary>È davvero gratis? Ci sono acquisti in-app?</summary>
+            <p>È completamente gratuito. Niente gacha, niente abbonamenti, nessun tipo di acquisto in-app. E per ora non mostriamo nemmeno pubblicità.</p>
+          </details>
+          <details>
+            <summary>Quanto dura una partita?</summary>
+            <p>Puoi scegliere tra 15, 20 o 30 minuti, a seconda dell'umore del momento. Va bene sia per una breve pausa sia per una camminata intensa nel weekend.</p>
+          </details>
+          <details>
+            <summary>Dove si può giocare?</summary>
+            <p>In linea di massima si gioca ovunque in città. In base al GPS, viene generata automaticamente una meta raggiungibile a piedi dalla tua posizione attuale.</p>
+          </details>
+          <details>
+            <summary>Quanti dati e quanta batteria consuma?</summary>
+            <p>Poiché la posizione viene rilevata di continuo, le sessioni lunghe tendono a consumare più batteria. Il consumo di dati riguarda soprattutto la visualizzazione della mappa e non è eccessivo.</p>
+          </details>
+          <details>
+            <summary>Come giocare in sicurezza?</summary>
+            <p>Fai sempre molta attenzione a non usare il telefono mentre cammini. Fermati prima degli attraversamenti pedonali, evita le strade buie e le zone poco frequentate, e rispetta sempre le regole di base per camminare in sicurezza.</p>
+          </details>
+          <details>
+            <summary>Esiste la versione Android?</summary>
+            <p>Al momento stiamo cercando tester in vista della pubblicazione su Google Play. Puoi registrarti come tester da <a href="/it/tester-android">questa pagina</a>.</p>
+          </details>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Final CTA ==================== -->
+    <section class="section cta-section" id="download">
+      <div class="container container--narrow">
+        <h2>Su, trasforma la passeggiata in avventura.</h2>
+        <p>Scarica subito l'app e muovi il primo passo verso un luogo che non conosci.</p>
+        <div class="hero__cta" style="justify-content: center;">
+          <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="Scarica sull'App Store">
+            <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/it-it?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
+          </a>
+          <a class="btn" href="/it/tester-android" style="background:#fff;">Android (cerchiamo tester)</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Contact ==================== -->
+    <section class="section" id="contact">
+      <div class="container">
+        <h2 class="section__title">Contatti</h2>
+        <p class="section__lead">Segnalazioni di bug, impressioni, proposte di collaborazione: scrivici pure liberamente.</p>
+        <div class="contact-card">
+          <p>Contattaci via email tramite il pulsante qui sotto.</p>
+          <a class="btn btn--lg" href="mailto:akmatsutaiki@gmail.com?subject=%E3%80%90%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%A9%E3%83%BC%E3%82%BA%E3%80%91%E3%81%8A%E5%95%8F%E3%81%84%E5%90%88%E3%82%8F%E3%81%9B">
+            Scrivici una email
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Footer ==================== -->
+    <footer class="site-footer">
+      <div class="container">
+        <div class="site-footer__grid">
+          <div>
+            <div class="site-footer__brand">Explores</div>
+            <p class="site-footer__brand-line">Il gioco di passeggiate urbane che trasforma la camminata in avventura.<br />by Prokonjo</p>
+          </div>
+          <div class="site-footer__col">
+            <h4>Sito</h4>
+            <ul>
+              <li><a href="#about">Caratteristiche</a></li>
+              <li><a href="#how">Come si gioca</a></li>
+              <li><a href="#awards">Riconoscimenti</a></li>
+              <li><a href="#faq">FAQ</a></li>
+            </ul>
+          </div>
+          <div class="site-footer__col">
+            <h4>Informazioni</h4>
+            <ul>
+              <li><a href="/it/privacy-policy/">Informativa sulla privacy</a></li>
+              <li><a href="#contact">Contatti</a></li>
+              <li><a href="/it/tester-android">Tester Android</a></li>
+            </ul>
+          </div>
+        </div>
+        <nav class="lang-switch" aria-label="Lingua / Language">
+          <span class="lang-switch__label">Lingua</span>
+          <a href="/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/" hreflang="en" lang="en">English</a>
+          <a href="/zh/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/" hreflang="it" lang="it" class="is-current" aria-current="true">Italiano</a>
+          <a href="/es/" hreflang="es" lang="es">Español</a>
+          <a href="/th/" hreflang="th" lang="th">ไทย</a>
+        </nav>
+        <div class="site-footer__bottom">
+          <span>© 2024-2026 Prokonjo. All rights reserved.</span>
+          <div class="site-footer__social">
+            <a href="https://github.com/prokonjo-team" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+              <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      // Mobile menu toggle
+      (function() {
+        var btn = document.querySelector('.menu-btn');
+        var menu = document.getElementById('mobile-menu');
+        if (!btn || !menu) return;
+        btn.addEventListener('click', function() {
+          var open = menu.dataset.open === 'true';
+          menu.dataset.open = open ? 'false' : 'true';
+          btn.setAttribute('aria-expanded', String(!open));
+        });
+        // Close on link tap
+        menu.querySelectorAll('a').forEach(function(a) {
+          a.addEventListener('click', function() {
+            menu.dataset.open = 'false';
+            btn.setAttribute('aria-expanded', 'false');
+          });
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/it/privacy-policy/index.html
+++ b/it/privacy-policy/index.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="it">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>Informativa sulla privacy｜Explores</title>
+    <meta name="description" content="Informativa sulla privacy di Explores. Trattamento dei dati di localizzazione e periodi di conservazione dei dati." />
+    <meta name="theme-color" content="#FACD00" />
+    <meta name="robots" content="noindex" />
+    <link rel="canonical" href="https://prokonjo.com/it/privacy-policy/" />
+    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/privacy-policy/" />
+    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/privacy-policy/" />
+    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/privacy-policy/" />
+    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/privacy-policy/" />
+    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/privacy-policy/" />
+    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/privacy-policy/" />
+    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/privacy-policy/" />
+    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/privacy-policy/" />
+    <link rel="icon" type="image/png" href="/assets/favicon.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/css/styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-P3YYZEG46Z');
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container site-header__inner">
+        <a class="site-header__brand" href="/it/" aria-label="Explores home">
+          <span class="site-header__brand-mark" aria-hidden="true">🧭</span>
+          <span>Explores</span>
+        </a>
+        <nav class="site-nav" aria-label="Main menu">
+          <a href="/it/#about">Caratteristiche</a>
+          <a href="/it/#how">Come si gioca</a>
+          <a href="/it/#awards">Risultati</a>
+          <a href="/it/#faq">FAQ</a>
+          <a href="/it/#contact">Contatti</a>
+        </nav>
+        <a class="btn site-header__cta" href="/it/#download" aria-label="Scarica">
+          <svg class="site-header__cta-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>
+          <span class="site-header__cta-label">Scarica</span>
+        </a>
+        <button class="menu-btn" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+        </button>
+      </div>
+      <div id="mobile-menu" data-open="false">
+        <a href="/it/#about">Caratteristiche</a>
+        <a href="/it/#how">Come si gioca</a>
+        <a href="/it/#awards">Risultati</a>
+        <a href="/it/#faq">FAQ</a>
+        <a href="/it/#contact">Contatti</a>
+        <a href="/it/privacy-policy/">Informativa sulla privacy</a>
+        <div class="mobile-menu__lang" aria-label="Lingua / Language">
+          <a href="/privacy-policy/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/privacy-policy/" hreflang="en" lang="en">English</a>
+          <a href="/zh/privacy-policy/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/privacy-policy/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/privacy-policy/" hreflang="it" lang="it" class="is-current" aria-current="true">Italiano</a>
+          <a href="/es/privacy-policy/" hreflang="es" lang="es">Español</a>
+          <a href="/th/privacy-policy/" hreflang="th" lang="th">ไทย</a>
+        </div>
+      </div>
+    </header>
+
+    <section class="page-header">
+      <div class="container">
+        <h1>Informativa sulla privacy</h1>
+        <p class="page-header__lead">Le informazioni trattate da Explores e le relative finalità di utilizzo.</p>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <article class="prose">
+          <p>La presente informativa sulla privacy si applica all'applicazione mobile «Explores» (di seguito «l'App») fornita gratuitamente da Taiki Akamatsu (di seguito «il Fornitore del servizio»). Il servizio è fornito sulla base di un utilizzo «così com'è».</p>
+
+          <h2>Informazioni raccolte e finalità di utilizzo</h2>
+          <p>L'App può raccogliere le seguenti informazioni al momento del download e dell'utilizzo.</p>
+          <ul>
+            <li>L'indirizzo IP del dispositivo</li>
+            <li>Le pagine visitate all'interno dell'App, la data e l'ora delle visite e il tempo trascorso</li>
+            <li>Il tempo di utilizzo dell'App</li>
+            <li>Il sistema operativo del dispositivo mobile utilizzato</li>
+          </ul>
+
+          <p>L'App raccoglie i dati di localizzazione del dispositivo. I dati di localizzazione vengono utilizzati per determinare la posizione geografica approssimativa e sono impiegati per le seguenti finalità.</p>
+          <ul>
+            <li><strong>Servizi basati sulla posizione</strong>: fornitura di contenuti personalizzati, suggerimenti pertinenti e funzionalità basate sulla posizione</li>
+            <li><strong>Analisi e miglioramenti</strong>: analisi del comportamento degli utenti e miglioramento delle prestazioni complessive dell'App sulla base di dati di localizzazione aggregati e anonimizzati</li>
+            <li><strong>Servizi di terze parti</strong>: i dati di localizzazione anonimizzati possono essere trasmessi a servizi esterni che contribuiscono a migliorare l'App e a ottimizzare i contenuti offerti</li>
+          </ul>
+
+          <p>Il Fornitore del servizio può utilizzare le informazioni raccolte allo scopo di contattarti (comunicazioni importanti, notifiche necessarie, comunicazioni di marketing e simili). Inoltre, per offrire un'esperienza migliore, potrebbe chiederti di fornire determinate informazioni che consentono di identificare una persona specifica; tali informazioni saranno utilizzate e conservate secondo quanto indicato nella presente informativa.</p>
+
+          <h2>Comunicazione delle informazioni a terzi</h2>
+          <p>Ai servizi esterni vengono trasmessi periodicamente solo dati aggregati e anonimizzati. Il Fornitore del servizio può condividere informazioni con terze parti secondo le modalità descritte nella presente informativa.</p>
+
+          <p>L'App utilizza servizi di terze parti dotati di una propria informativa sulla privacy. Per le informative sulla privacy dei servizi di terze parti utilizzati, consulta quanto segue.</p>
+          <ul>
+            <li><a href="https://www.google.com/policies/privacy/" target="_blank" rel="noopener noreferrer">Google Play Services</a></li>
+          </ul>
+
+          <p>Il Fornitore del servizio può divulgare le informazioni fornite dall'utente e quelle raccolte automaticamente nei seguenti casi.</p>
+          <ul>
+            <li>Quando richiesto dalla legge, ad esempio per rispondere a un mandato di comparizione o a procedure legali analoghe</li>
+            <li>Quando ritenuto in buona fede necessario per tutelare i diritti del Fornitore del servizio, garantire la sicurezza degli utenti o di terzi, indagare su frodi o rispondere a richieste delle autorità</li>
+            <li>Quando affidato a fornitori di servizi affidabili che operano per conto del Fornitore del servizio e che hanno accettato di non utilizzare le informazioni in modo indipendente e di attenersi alla presente informativa</li>
+          </ul>
+
+          <h2>Opt-out</h2>
+          <p>Disinstallando l'App puoi interrompere completamente la raccolta delle informazioni. Utilizza la procedura di disinstallazione standard del tuo dispositivo o dello store.</p>
+
+          <h2>Periodo di conservazione dei dati</h2>
+          <p>Il Fornitore del servizio conserva i dati forniti dall'utente durante l'utilizzo dell'App e per il periodo ritenuto ragionevole. Se desideri che i dati forniti tramite l'App vengano eliminati, contattaci all'indirizzo <a href="mailto:akmatsutaiki@gmail.com">akmatsutaiki@gmail.com</a>. Provvederemo entro un periodo ragionevole.</p>
+
+          <h2>Utilizzo da parte dei minori</h2>
+          <p>Il Fornitore del servizio non raccoglie intenzionalmente dati da minori di 13 anni né svolge attività di marketing nei loro confronti tramite l'App.</p>
+          <p>L'App non è destinata ai minori di 13 anni. Qualora dovesse emergere di aver ricevuto dati personali da un minore di 13 anni, questi verranno immediatamente eliminati dai server. Se sei un genitore e ti accorgi che tuo figlio ha fornito dati personali, contattaci all'indirizzo <a href="mailto:akmatsutaiki@gmail.com">akmatsutaiki@gmail.com</a>.</p>
+
+          <h2>Sicurezza</h2>
+          <p>Il Fornitore del servizio si impegna a preservare la riservatezza delle informazioni dell'utente. Per proteggere i dati trattati e conservati, adotta misure di sicurezza fisiche, elettroniche e procedurali.</p>
+
+          <h2>Modifiche alla presente informativa</h2>
+          <p>La presente informativa sulla privacy può essere aggiornata di volta in volta, secondo necessità. Il Fornitore del servizio comunica le modifiche aggiornando questa pagina. L'utilizzo continuato è considerato accettazione di tutte le modifiche; ti invitiamo pertanto a consultarla periodicamente.</p>
+
+          <p>Data di entrata in vigore della presente informativa sulla privacy: <strong>2024-05-06</strong></p>
+
+          <h2>Consenso</h2>
+          <p>L'utilizzo dell'App è considerato come accettazione del trattamento delle tue informazioni secondo quanto previsto dalla presente informativa sulla privacy.</p>
+
+          <h2>Contatti</h2>
+          <p>Per qualsiasi domanda sulla privacy relativa all'utilizzo dell'App o sulla presente informativa, contattaci via e-mail all'indirizzo <a href="mailto:akmatsutaiki@gmail.com">akmatsutaiki@gmail.com</a>.</p>
+
+          <hr />
+          <p style="font-size: 0.86rem; color: var(--c-text-muted);">Per la redazione della presente informativa è stato utilizzato <a href="https://app-privacy-policy-generator.nisrulz.com/" target="_blank" rel="noopener noreferrer">App Privacy Policy Generator</a>.</p>
+        </article>
+      </div>
+    </section>
+
+    <footer class="site-footer">
+      <div class="container">
+        <div class="site-footer__grid">
+          <div>
+            <div class="site-footer__brand">Explores</div>
+            <p class="site-footer__brand-line">Il gioco di esplorazione urbana che trasforma la passeggiata in un'avventura.<br />by Prokonjo (prokonjo)</p>
+          </div>
+          <div class="site-footer__col">
+            <h4>Sito</h4>
+            <ul>
+              <li><a href="/it/#about">Caratteristiche</a></li>
+              <li><a href="/it/#how">Come si gioca</a></li>
+              <li><a href="/it/#awards">Risultati</a></li>
+              <li><a href="/it/#faq">FAQ</a></li>
+            </ul>
+          </div>
+          <div class="site-footer__col">
+            <h4>Informazioni sulla gestione</h4>
+            <ul>
+              <li><a href="/it/privacy-policy/">Informativa sulla privacy</a></li>
+              <li><a href="/it/#contact">Contatti</a></li>
+              <li><a href="/it/tester-android/">Tester Android</a></li>
+            </ul>
+          </div>
+        </div>
+        <nav class="lang-switch" aria-label="Lingua / Language">
+          <span class="lang-switch__label">Lingua</span>
+          <a href="/privacy-policy/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/privacy-policy/" hreflang="en" lang="en">English</a>
+          <a href="/zh/privacy-policy/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/privacy-policy/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/privacy-policy/" hreflang="it" lang="it" class="is-current" aria-current="true">Italiano</a>
+          <a href="/es/privacy-policy/" hreflang="es" lang="es">Español</a>
+          <a href="/th/privacy-policy/" hreflang="th" lang="th">ไทย</a>
+        </nav>
+        <div class="site-footer__bottom">
+          <span>© 2024-2026 Prokonjo (prokonjo). All rights reserved.</span>
+          <div class="site-footer__social">
+            <a href="https://github.com/prokonjo-team" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+              <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      (function() {
+        var btn = document.querySelector('.menu-btn');
+        var menu = document.getElementById('mobile-menu');
+        if (!btn || !menu) return;
+        btn.addEventListener('click', function() {
+          var open = menu.dataset.open === 'true';
+          menu.dataset.open = open ? 'false' : 'true';
+          btn.setAttribute('aria-expanded', String(!open));
+        });
+        menu.querySelectorAll('a').forEach(function(a) {
+          a.addEventListener('click', function() {
+            menu.dataset.open = 'false';
+            btn.setAttribute('aria-expanded', 'false');
+          });
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/it/tester-android/index.html
+++ b/it/tester-android/index.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="it">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>Cerchiamo tester Android｜Explores</title>
+    <meta name="description" content="Pagina di reclutamento tester Android di Explores. Tre passaggi: iscrizione a Google Groups → installazione dell'app → avvio." />
+    <meta name="theme-color" content="#FACD00" />
+    <meta name="robots" content="noindex" />
+    <link rel="canonical" href="https://prokonjo.com/it/tester-android/" />
+    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/tester-android/" />
+    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/tester-android/" />
+    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/tester-android/" />
+    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/tester-android/" />
+    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/tester-android/" />
+    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/tester-android/" />
+    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/tester-android/" />
+    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/tester-android/" />
+    <link rel="icon" type="image/png" href="/assets/favicon.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/css/styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-P3YYZEG46Z');
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container site-header__inner">
+        <a class="site-header__brand" href="/it/" aria-label="Explores home">
+          <span class="site-header__brand-mark" aria-hidden="true">🧭</span>
+          <span>Explores</span>
+        </a>
+        <nav class="site-nav" aria-label="Main menu">
+          <a href="/it/#about">Caratteristiche</a>
+          <a href="/it/#how">Come si gioca</a>
+          <a href="/it/#awards">Riconoscimenti</a>
+          <a href="/it/#faq">FAQ</a>
+          <a href="/it/#contact">Contatti</a>
+        </nav>
+        <a class="btn site-header__cta" href="/it/#download" aria-label="Scarica">
+          <svg class="site-header__cta-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>
+          <span class="site-header__cta-label">Scarica</span>
+        </a>
+        <button class="menu-btn" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+        </button>
+      </div>
+      <div id="mobile-menu" data-open="false">
+        <a href="/it/#about">Caratteristiche</a>
+        <a href="/it/#how">Come si gioca</a>
+        <a href="/it/#awards">Riconoscimenti</a>
+        <a href="/it/#faq">FAQ</a>
+        <a href="/it/#contact">Contatti</a>
+        <a href="/it/privacy-policy/">Informativa sulla privacy</a>
+        <div class="mobile-menu__lang" aria-label="Lingua / Language">
+          <a href="/tester-android/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/tester-android/" hreflang="en" lang="en">English</a>
+          <a href="/zh/tester-android/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/tester-android/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/tester-android/" hreflang="it" lang="it" class="is-current" aria-current="true">Italiano</a>
+          <a href="/es/tester-android/" hreflang="es" lang="es">Español</a>
+          <a href="/th/tester-android/" hreflang="th" lang="th">ไทย</a>
+        </div>
+      </div>
+    </header>
+
+    <section class="page-header">
+      <div class="container">
+        <h1>Cerchiamo tester Android</h1>
+        <p class="page-header__lead">In vista della pubblicazione su Google Play, cerchiamo persone che vogliano provare Explores in anteprima su Android. Bastano 3 passaggi per partecipare!</p>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container container--narrow">
+        <div class="callout" style="margin-bottom: 2.5rem;">
+          <span class="callout__icon" aria-hidden="true">💡</span>
+          <div class="callout__body">
+            <strong>Cosa ti chiediamo come tester</strong>
+            <p>Tre cose: installare l'app Android (obbligatorio), avviarla (obbligatorio) e rispondere al questionario (facoltativo).</p>
+          </div>
+        </div>
+
+        <div class="tester-step">
+          <div class="tester-step__num">1</div>
+          <div class="tester-step__body">
+            <h3>Iscriviti a Google Groups</h3>
+            <p>Iscriviti a Google Groups tramite il link qui sotto. Se non fai parte del Google Groups dedicato ai tester, l'app non sarà visibile su Google Play.</p>
+            <a class="btn" href="https://groups.google.com/search?q=explores_tester&inOrg=false" target="_blank" rel="noopener noreferrer">Iscriviti a Google Groups</a>
+            <div class="tester-step__images">
+              <img src="/tester-android/imgs/1.png" alt="Iscrizione a Google Groups, passaggio 1" loading="lazy" />
+              <img src="/tester-android/imgs/2.png" alt="Iscrizione a Google Groups, passaggio 2" loading="lazy" />
+            </div>
+          </div>
+        </div>
+
+        <div class="tester-step">
+          <div class="tester-step__num">2</div>
+          <div class="tester-step__body">
+            <h3>Installa l'app</h3>
+            <p>Una volta che l'iscrizione a Google Groups è stata registrata, installa l'app da Google Play tramite il link qui sotto.</p>
+            <a class="btn" href="https://play.google.com/store/apps/details?id=com.prokonjo.explores" target="_blank" rel="noopener noreferrer">Installa da Google Play</a>
+            <p style="margin-top: 1rem; font-size: 0.92rem;">Se compare il messaggio "L'URL richiesto non è stato trovato su questo server.", è possibile che l'iscrizione a Google Groups non sia ancora stata registrata. Attendi qualche minuto e riprova.</p>
+          </div>
+        </div>
+
+        <div class="tester-step">
+          <div class="tester-step__num">3</div>
+          <div class="tester-step__body">
+            <h3>Avvia l'app</h3>
+            <p>Dopo l'installazione, avvia l'app una volta per completare la registrazione come tester.</p>
+            <div class="callout">
+              <span class="callout__icon" aria-hidden="true">⚠️</span>
+              <div class="callout__body">
+                <strong>Importante</strong>
+                <p>Una volta installata, ti chiediamo di non eliminare l'app. Se la disinstalli, verrai rimosso dai tester.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="tester-step">
+          <div class="tester-step__num">+</div>
+          <div class="tester-step__body">
+            <h3>(Facoltativo) Aiutaci con il questionario</h3>
+            <p>Il tuo feedback sull'esperienza d'uso ci aiuta a migliorare l'app.</p>
+            <a class="btn btn--secondary" href="https://docs.google.com/forms/d/1sWQDp1t_8PnzxENLO9BHw-IYn2yrNgumjZMQWQWam8I" target="_blank" rel="noopener noreferrer">Rispondi al questionario</a>
+          </div>
+        </div>
+
+        <div style="text-align: center; margin-top: 3rem;">
+          <a class="btn btn--ghost" href="/it/">Torna alla home</a>
+        </div>
+      </div>
+    </section>
+
+    <footer class="site-footer">
+      <div class="container">
+        <div class="site-footer__grid">
+          <div>
+            <div class="site-footer__brand">Explores</div>
+            <p class="site-footer__brand-line">Il gioco di passeggiate urbane che trasforma una camminata in un'avventura.<br />by Prokonjo</p>
+          </div>
+          <div class="site-footer__col">
+            <h4>Sito</h4>
+            <ul>
+              <li><a href="/it/#about">Caratteristiche</a></li>
+              <li><a href="/it/#how">Come si gioca</a></li>
+              <li><a href="/it/#awards">Riconoscimenti</a></li>
+              <li><a href="/it/#faq">FAQ</a></li>
+            </ul>
+          </div>
+          <div class="site-footer__col">
+            <h4>Informazioni</h4>
+            <ul>
+              <li><a href="/it/privacy-policy/">Informativa sulla privacy</a></li>
+              <li><a href="/it/#contact">Contatti</a></li>
+              <li><a href="/it/tester-android/">Tester Android</a></li>
+            </ul>
+          </div>
+        </div>
+        <nav class="lang-switch" aria-label="Lingua / Language">
+          <span class="lang-switch__label">Lingua</span>
+          <a href="/tester-android/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/tester-android/" hreflang="en" lang="en">English</a>
+          <a href="/zh/tester-android/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/tester-android/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/tester-android/" hreflang="it" lang="it" class="is-current" aria-current="true">Italiano</a>
+          <a href="/es/tester-android/" hreflang="es" lang="es">Español</a>
+          <a href="/th/tester-android/" hreflang="th" lang="th">ไทย</a>
+        </nav>
+        <div class="site-footer__bottom">
+          <span>© 2024-2026 Prokonjo. All rights reserved.</span>
+          <div class="site-footer__social">
+            <a href="https://github.com/prokonjo-team" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+              <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      (function() {
+        var btn = document.querySelector('.menu-btn');
+        var menu = document.getElementById('mobile-menu');
+        if (!btn || !menu) return;
+        btn.addEventListener('click', function() {
+          var open = menu.dataset.open === 'true';
+          menu.dataset.open = open ? 'false' : 'true';
+          btn.setAttribute('aria-expanded', String(!open));
+        });
+        menu.querySelectorAll('a').forEach(function(a) {
+          a.addEventListener('click', function() {
+            menu.dataset.open = 'false';
+            btn.setAttribute('aria-expanded', 'false');
+          });
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -8,6 +8,14 @@
     <meta name="theme-color" content="#FACD00" />
     <meta name="robots" content="noindex" />
     <link rel="canonical" href="https://prokonjo.com/privacy-policy/" />
+    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/privacy-policy/" />
+    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/privacy-policy/" />
+    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/privacy-policy/" />
+    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/privacy-policy/" />
+    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/privacy-policy/" />
+    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/privacy-policy/" />
+    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/privacy-policy/" />
+    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/privacy-policy/" />
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -35,7 +43,10 @@
           <a href="/#faq">FAQ</a>
           <a href="/#contact">お問い合わせ</a>
         </nav>
-        <a class="btn site-header__cta" href="/#download">ダウンロード</a>
+        <a class="btn site-header__cta" href="/#download" aria-label="ダウンロード">
+          <svg class="site-header__cta-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>
+          <span class="site-header__cta-label">ダウンロード</span>
+        </a>
         <button class="menu-btn" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="メニューを開く">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
         </button>
@@ -47,6 +58,15 @@
         <a href="/#faq">FAQ</a>
         <a href="/#contact">お問い合わせ</a>
         <a href="/privacy-policy/">プライバシーポリシー</a>
+        <div class="mobile-menu__lang" aria-label="言語 / Language">
+          <a href="/privacy-policy/" hreflang="ja" lang="ja" class="is-current" aria-current="true">日本語</a>
+          <a href="/en/privacy-policy/" hreflang="en" lang="en">English</a>
+          <a href="/zh/privacy-policy/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/privacy-policy/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/privacy-policy/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/privacy-policy/" hreflang="es" lang="es">Español</a>
+          <a href="/th/privacy-policy/" hreflang="th" lang="th">ไทย</a>
+        </div>
       </div>
     </header>
 
@@ -150,6 +170,16 @@
             </ul>
           </div>
         </div>
+        <nav class="lang-switch" aria-label="言語 / Language">
+          <span class="lang-switch__label">言語</span>
+          <a href="/privacy-policy/" hreflang="ja" lang="ja" class="is-current" aria-current="true">日本語</a>
+          <a href="/en/privacy-policy/" hreflang="en" lang="en">English</a>
+          <a href="/zh/privacy-policy/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/privacy-policy/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/privacy-policy/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/privacy-policy/" hreflang="es" lang="es">Español</a>
+          <a href="/th/privacy-policy/" hreflang="th" lang="th">ไทย</a>
+        </nav>
         <div class="site-footer__bottom">
           <span>© 2024-2026 プロ根性 (prokonjo). All rights reserved.</span>
           <div class="site-footer__social">

--- a/tester-android/index.html
+++ b/tester-android/index.html
@@ -8,6 +8,14 @@
     <meta name="theme-color" content="#FACD00" />
     <meta name="robots" content="noindex" />
     <link rel="canonical" href="https://prokonjo.com/tester-android/" />
+    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/tester-android/" />
+    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/tester-android/" />
+    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/tester-android/" />
+    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/tester-android/" />
+    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/tester-android/" />
+    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/tester-android/" />
+    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/tester-android/" />
+    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/tester-android/" />
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -35,7 +43,10 @@
           <a href="/#faq">FAQ</a>
           <a href="/#contact">お問い合わせ</a>
         </nav>
-        <a class="btn site-header__cta" href="/#download">ダウンロード</a>
+        <a class="btn site-header__cta" href="/#download" aria-label="ダウンロード">
+          <svg class="site-header__cta-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>
+          <span class="site-header__cta-label">ダウンロード</span>
+        </a>
         <button class="menu-btn" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="メニューを開く">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
         </button>
@@ -47,6 +58,15 @@
         <a href="/#faq">FAQ</a>
         <a href="/#contact">お問い合わせ</a>
         <a href="/privacy-policy/">プライバシーポリシー</a>
+        <div class="mobile-menu__lang" aria-label="言語 / Language">
+          <a href="/tester-android/" hreflang="ja" lang="ja" class="is-current" aria-current="true">日本語</a>
+          <a href="/en/tester-android/" hreflang="en" lang="en">English</a>
+          <a href="/zh/tester-android/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/tester-android/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/tester-android/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/tester-android/" hreflang="es" lang="es">Español</a>
+          <a href="/th/tester-android/" hreflang="th" lang="th">ไทย</a>
+        </div>
       </div>
     </header>
 
@@ -145,6 +165,16 @@
             </ul>
           </div>
         </div>
+        <nav class="lang-switch" aria-label="言語 / Language">
+          <span class="lang-switch__label">言語</span>
+          <a href="/tester-android/" hreflang="ja" lang="ja" class="is-current" aria-current="true">日本語</a>
+          <a href="/en/tester-android/" hreflang="en" lang="en">English</a>
+          <a href="/zh/tester-android/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/tester-android/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/tester-android/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/tester-android/" hreflang="es" lang="es">Español</a>
+          <a href="/th/tester-android/" hreflang="th" lang="th">ไทย</a>
+        </nav>
         <div class="site-footer__bottom">
           <span>© 2024-2026 プロ根性 (prokonjo). All rights reserved.</span>
           <div class="site-footer__social">

--- a/th/index.html
+++ b/th/index.html
@@ -1,0 +1,450 @@
+<!DOCTYPE html>
+<html lang="th">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>Explores｜เกมเดินสำรวจเมืองที่เปลี่ยนการเดินเล่นให้เป็นการผจญภัย</title>
+    <meta name="description" content="Explores เกมเดินสำรวจเมืองที่เปลี่ยนการเดินเล่นธรรมดาให้กลายเป็นการผจญภัย ใช้รูปภาพเป็นใบ้แล้วเดินไปยังสถานที่ที่ไม่เคยรู้จัก เล่นรอบละราว 15 นาที ฟรี ไม่มีระบบเติมเงิน" />
+    <meta name="author" content="Prokonjo" />
+    <meta name="theme-color" content="#FACD00" />
+    <link rel="canonical" href="https://prokonjo.com/th/" />
+
+    <!-- hreflang alternates -->
+    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/" />
+    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/" />
+    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/" />
+    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/" />
+    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/" />
+    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/" />
+    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/" />
+    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/" />
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Explores" />
+    <meta property="og:title" content="Explores｜เกมเดินสำรวจเมืองที่เปลี่ยนการเดินเล่นให้เป็นการผจญภัย" />
+    <meta property="og:description" content="เกมเดินสำรวจเมืองที่ใช้รูปภาพเป็นใบ้ แล้วเดินไปยังสถานที่ที่ไม่เคยรู้จัก เล่นรอบละราว 15 นาที ฟรี ไม่มีระบบเติมเงิน" />
+    <meta property="og:url" content="https://prokonjo.com/th/" />
+    <meta property="og:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+    <meta property="og:image:type" content="image/jpeg" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:locale" content="th_TH" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Explores｜เกมเดินสำรวจเมืองที่เปลี่ยนการเดินเล่นให้เป็นการผจญภัย" />
+    <meta name="twitter:description" content="เกมเดินสำรวจเมืองที่ใช้รูปภาพเป็นใบ้ แล้วเดินไปยังสถานที่ที่ไม่เคยรู้จัก เล่นรอบละราว 15 นาที ฟรี ไม่มีระบบเติมเงิน" />
+    <meta name="twitter:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" href="/assets/favicon.png" />
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+
+    <link rel="stylesheet" href="/css/styles.css" />
+
+    <!-- Structured data -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "MobileApplication",
+        "name": "Explores",
+        "description": "เกมเดินสำรวจเมืองที่เปลี่ยนการเดินเล่นให้เป็นการผจญภัย ใช้รูปภาพเป็นใบ้แล้วเดินไปยังสถานที่ที่ไม่เคยรู้จัก ประสบการณ์การสำรวจรอบละราว 15 นาที",
+        "url": "https://prokonjo.com/th/",
+        "applicationCategory": "GameApplication",
+        "operatingSystem": "iOS",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "JPY"
+        },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Prokonjo",
+          "url": "https://prokonjo.com/"
+        }
+      }
+    </script>
+
+    <!-- Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-P3YYZEG46Z');
+    </script>
+  </head>
+  <body>
+    <!-- ==================== Header ==================== -->
+    <header class="site-header">
+      <div class="container site-header__inner">
+        <a class="site-header__brand" href="#top" aria-label="หน้าแรก Explores">
+          <span class="site-header__brand-mark" aria-hidden="true">🧭</span>
+          <span>Explores</span>
+        </a>
+        <nav class="site-nav" aria-label="เมนูหลัก">
+          <a href="#about">จุดเด่น</a>
+          <a href="#how">วิธีเล่น</a>
+          <a href="#awards">ผลงาน</a>
+          <a href="#faq">คำถามที่พบบ่อย</a>
+          <a href="#contact">ติดต่อเรา</a>
+        </nav>
+        <a class="btn site-header__cta" href="#download" aria-label="ดาวน์โหลด">
+          <svg class="site-header__cta-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>
+          <span class="site-header__cta-label">ดาวน์โหลด</span>
+        </a>
+        <button class="menu-btn" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="เปิดเมนู">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+        </button>
+      </div>
+      <div id="mobile-menu" data-open="false">
+        <a href="#about">จุดเด่น</a>
+        <a href="#how">วิธีเล่น</a>
+        <a href="#awards">ผลงาน</a>
+        <a href="#faq">คำถามที่พบบ่อย</a>
+        <a href="#contact">ติดต่อเรา</a>
+        <a href="/th/privacy-policy/">นโยบายความเป็นส่วนตัว</a>
+        <div class="mobile-menu__lang" aria-label="ภาษา / Language">
+          <a href="/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/" hreflang="en" lang="en">English</a>
+          <a href="/zh/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/" hreflang="es" lang="es">Español</a>
+          <a href="/th/" hreflang="th" lang="th" class="is-current" aria-current="true">ไทย</a>
+        </div>
+      </div>
+    </header>
+
+    <!-- ==================== Hero ==================== -->
+    <section class="hero" id="top">
+      <div class="container hero__inner">
+        <div>
+          <span class="hero__eyebrow">🧭 เกมเดินสำรวจเมือง</span>
+          <h1 class="hero__title">เปลี่ยนการเดินเล่นให้เป็น<em>การผจญภัย</em></h1>
+          <p class="hero__sub">
+            ใช้รูปภาพเป็นใบ้ แล้วออกเดินไปยังสถานที่ที่คุณไม่เคยรู้จัก<br />
+            เล่นรอบละราว 15 นาที เกมเดินสำรวจเมืองที่ฟรีและไม่มีระบบเติมเงิน
+          </p>
+          <div class="hero__cta">
+            <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="ดาวน์โหลดบน App Store">
+              <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/th-th?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
+            </a>
+            <a class="btn btn--secondary" href="/th/tester-android">Android (กำลังรับสมัครผู้ทดสอบ)</a>
+          </div>
+          <p class="hero__note">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>
+            ฟรี ／ ไม่มีระบบเติมเงิน ／ ไม่มีโฆษณา
+          </p>
+        </div>
+        <div class="hero__visual">
+          <img src="/assets/img/game-desc.jpg" alt="ภาพตัวอย่างการเล่น Explores" width="1200" height="676" />
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Empathy ==================== -->
+    <section class="section section--alt" id="about">
+      <div class="container">
+        <h2 class="section__title">เบื่อกับการเดินเล่นแบบเดิม ๆ ไหม?</h2>
+        <p class="section__lead">ตั้งใจจะเดินออกกำลังกาย แต่เส้นทางเดิมทุกวันก็ทำให้เลิกไปกลางคัน<br />ถ้ามี "การเดินที่มีเป้าหมาย" สักหน่อย บางทีอาจเดินต่อได้นานขึ้นก็ได้</p>
+        <div class="card-grid">
+          <div class="empathy-card">
+            <div class="empathy-card__icon" aria-hidden="true">🛣️</div>
+            <h3>เบื่อกับเส้นทางเดิมทุกวัน</h3>
+            <p>เดินไป-กลับระหว่างบ้านกับสถานี รู้ตัวอีกทีก็เดินไปโดยไม่ได้มองวิวเลย</p>
+          </div>
+          <div class="empathy-card">
+            <div class="empathy-card__icon" aria-hidden="true">📉</div>
+            <h3>ไม่เป็นนิสัย เลยทำต่อไม่ได้</h3>
+            <p>ตั้งใจว่า "จะเดินนะ" แต่พอผ่านไปสามวันก็ลืมสนิท</p>
+          </div>
+          <div class="empathy-card">
+            <div class="empathy-card__icon" aria-hidden="true">🤔</div>
+            <h3>ไม่มีเป้าหมายในการเดิน</h3>
+            <p>ถ้าเดินเพื่อออกกำลังกายอย่างเดียว แรงจูงใจก็ไม่ค่อยคงอยู่</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Value ==================== -->
+    <section class="section">
+      <div class="container">
+        <h2 class="section__title">ด้วย Explores<br />การเดินเล่นจะกลายเป็นการผจญภัย</h2>
+        <p class="section__lead">มีแค่รูปภาพเป็นใบ้ ก็มุ่งหน้าไปยังสถานที่ที่ไม่เคยรู้จักได้<br />เป้าหมายไม่ซ้ำกันทุกครั้ง จบใน 15 นาที "เหตุผลที่จะออกเดิน" อยู่ตรงนี้แล้ว</p>
+        <div class="card-grid">
+          <div class="value-card">
+            <div class="value-card__badge">01</div>
+            <h3>เป้าหมายต่างกันทุกครั้ง</h3>
+            <p>ระบบจะสุ่มจุดหมายปลายทางใหม่ทุกครั้งตามเวลาที่คุณเลือก ไม่มีวันเบื่อกับสถานที่เดิม ๆ</p>
+          </div>
+          <div class="value-card">
+            <div class="value-card__badge">02</div>
+            <h3>ความรู้สึกผจญภัยด้วยรูปภาพใบ้</h3>
+            <p>เดินโดยอาศัยรูปภาพบริเวณจุดหมาย ไม่ใช่แผนที่ "อาคารนั่นเคยเห็นที่ไหนนะ…" คือจุดเริ่มต้นของการผจญภัย</p>
+          </div>
+          <div class="value-card">
+            <div class="value-card__badge">03</div>
+            <h3>จบใน 15 นาที</h3>
+            <p>ระหว่างเดินทางกลับ ช่วงพัก หรือเดินเล่นวันหยุด เริ่มเมื่อไหร่ก็ได้ หยุดเมื่อไหร่ก็ได้ เบาสบายแบบนี้เลย</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== How ==================== -->
+    <section class="section section--surface" id="how">
+      <div class="container">
+        <h2 class="section__title">วิธีเล่นแค่ 3 ขั้นตอน</h2>
+        <p class="section__lead">จากเปิดแอปจนออกไปเดินบนถนนใช้เวลาแค่ 30 วินาที</p>
+        <div class="steps">
+          <div class="step">
+            <div class="step__num">1</div>
+            <img class="step__img" src="/assets/img/game-play0.png" alt="หน้าจอเลือกเวลา" loading="lazy" />
+            <h3>เลือกเวลา</h3>
+            <p>เลือกเวลาที่อยากเดิน เช่น "15 นาที" "30 นาที" ตามอารมณ์ในตอนนั้น</p>
+          </div>
+          <div class="step">
+            <div class="step__num">2</div>
+            <img class="step__img" src="/assets/img/game-play1.png" alt="หน้าจอตรวจสอบรูปภาพและแผนที่บริเวณจุดหมาย" loading="lazy" />
+            <h3>จดจำจุดหมายให้ดี</h3>
+            <p>ดูรูปภาพและแผนที่บริเวณจุดหมายให้ละเอียดก่อนเริ่มเกม พอเริ่มแล้วทั้งหมดจะถูกซ่อนไป</p>
+          </div>
+          <div class="step">
+            <div class="step__num">3</div>
+            <img class="step__img" src="/assets/img/game-play2.png" alt="หน้าจอเกมระหว่างการสำรวจ" loading="lazy" />
+            <h3>เดินโดยอาศัยความทรงจำ</h3>
+            <p>เดินไปยังจุดหมายโดยมีแค่เวลาที่เหลือและระยะทางเป็นตัวช่วย "อ๊ะ นี่มันวิวในรูปนั่นนี่!"</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Video ==================== -->
+    <section class="section">
+      <div class="container">
+        <h2 class="section__title">ดู Explores ผ่านวิดีโอ</h2>
+        <p class="section__lead">เชิญชมหน้าจอการเล่นจริงและบรรยากาศการเดินสำรวจเมือง</p>
+        <div class="video-wrap">
+          <iframe src="https://www.youtube.com/embed/ldIJdk3zwHY?si=jwntDJV8pnRAHKio" title="วิดีโอแนะนำวิธีเล่น Explores" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Awards ==================== -->
+    <section class="section section--alt" id="awards">
+      <div class="container">
+        <h2 class="section__title">รางวัลที่ได้รับ</h2>
+        <p class="section__lead">ผลงานการประกวดที่สั่งสมมาตั้งแต่สมัยเป็นนักศึกษา</p>
+        <div class="awards">
+          <article class="award">
+            <img src="/assets/img/award-gikuhaku.jpg" alt="ได้รับรางวัลพิเศษจากบริษัทในงาน Gikuhaku" loading="lazy" />
+            <div class="award__body">
+              <span class="award__tag">รางวัลพิเศษจากบริษัท</span>
+              <h3>Gikuhaku</h3>
+              <p>Explores ได้รับรางวัลพิเศษจากบริษัทในงาน Gikuhaku ซึ่งจัดโดย Supporterz</p>
+              <a class="award__link" href="https://x.com/geek_pjt/status/1789225529109057540" target="_blank" rel="noopener noreferrer">ดูโพสต์ประกาศรางวัล →</a>
+            </div>
+          </article>
+          <article class="award">
+            <img src="/assets/img/award-wakayama.jpg" alt="ได้รับรางวัลยอดเยี่ยมในการประกวดนวัตกรรมการเขียนโปรแกรมวากายามะ" loading="lazy" />
+            <div class="award__body">
+              <span class="award__tag">รางวัลยอดเยี่ยม</span>
+              <h3>การประกวดนวัตกรรมการเขียนโปรแกรมวากายามะ</h3>
+              <p>ได้รับรางวัลยอดเยี่ยมจากแผนแอปสมาร์ตโฟนที่ช่วยแก้ปัญหาในจังหวัดวากายามะ</p>
+              <a class="award__link" href="https://wakayama-innovation-lab.relic.co.jp/" target="_blank" rel="noopener noreferrer">ดูข้อมูลผู้จัดงาน →</a>
+            </div>
+          </article>
+          <article class="award">
+            <img src="/assets/img/award-iizuka.jpg" alt="ได้รับรางวัลนายกเทศมนตรีในงาน e-ZUKA Smart App Contest 2023" loading="lazy" />
+            <div class="award__body">
+              <span class="award__tag">รางวัลนายกเทศมนตรี + รางวัลพิเศษจากบริษัท</span>
+              <h3>e-ZUKA Smart App Contest 2023</h3>
+              <p>คว้าทั้งรางวัลนายกเทศมนตรีเมืองอีซูกะและรางวัลพิเศษจากบริษัทในงานประกวดที่จัดโดยเมืองอีซูกะ จังหวัดฟุกุโอกะ</p>
+              <a class="award__link" href="http://e-zuka.info/2023/resurt.html" target="_blank" rel="noopener noreferrer">ดูผลการแข่งขัน →</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Members ==================== -->
+    <section class="section" id="members">
+      <div class="container">
+        <h2 class="section__title">ทีมพัฒนา</h2>
+        <p class="section__lead">ทีม 4 คนที่ตั้งใจสร้าง "การเปลี่ยนการเดินเล่นให้เป็นการผจญภัย" อย่างจริงจัง</p>
+        <div class="members">
+          <div class="member">
+            <img src="/assets/img/member-akamatsu.png" alt="Taiki Akamatsu" loading="lazy" width="96" height="96" />
+            <h3>Taiki Akamatsu</h3>
+            <p>หัวหน้าทีม / วิศวกร</p>
+            <div class="member__links">
+              <a href="https://www.wantedly.com/id/akamatsu_taiki" target="_blank" rel="noopener noreferrer" aria-label="โปรไฟล์ Wantedly">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3a14 14 0 010 18M12 3a14 14 0 000 18"/></svg>
+              </a>
+              <a href="https://github.com/Taiki-sub" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+              </a>
+            </div>
+          </div>
+          <div class="member">
+            <img src="/assets/img/member-chang.png" alt="Chang Ju-young" loading="lazy" width="96" height="96" />
+            <h3>Chang Ju-young</h3>
+            <p>นักออกแบบ</p>
+          </div>
+          <div class="member">
+            <img src="/assets/img/siteTop4.jpg" alt="Kento Kusumoto" loading="lazy" width="96" height="96" />
+            <h3>Kento Kusumoto</h3>
+            <p>นักออกแบบ</p>
+          </div>
+          <div class="member">
+            <img src="/assets/img/member-hayashi.png" alt="Shinichiro Hayashi" loading="lazy" width="96" height="96" />
+            <h3>Shinichiro Hayashi</h3>
+            <p>วิศวกร</p>
+            <div class="member__links">
+              <a href="https://www.github.com/hashin2425" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== FAQ ==================== -->
+    <section class="section section--surface" id="faq">
+      <div class="container">
+        <h2 class="section__title">คำถามที่พบบ่อย</h2>
+        <p class="section__lead">รวบรวมข้อสงสัยที่หลายคนอยากรู้ก่อนเริ่มเล่น</p>
+        <div class="faq">
+          <details>
+            <summary>ฟรีจริงไหม? มีระบบเติมเงินหรือเปล่า?</summary>
+            <p>ฟรีทั้งหมด ไม่มีระบบเติมเงินใด ๆ ทั้งกาชาหรือสมาชิกรายเดือน และตอนนี้ก็ยังไม่มีโฆษณาแสดงด้วย</p>
+          </details>
+          <details>
+            <summary>เล่นหนึ่งรอบใช้เวลานานแค่ไหน?</summary>
+            <p>เลือกได้ตามอารมณ์ในตอนนั้น เช่น 15 นาที 20 นาที หรือ 30 นาที จะเป็นช่วงเวลาว่างสั้น ๆ หรือวันหยุดที่อยากเดินยาว ๆ ก็เล่นได้ทั้งคู่</p>
+          </details>
+          <details>
+            <summary>เล่นได้ในสถานที่แบบไหนบ้าง?</summary>
+            <p>โดยพื้นฐานสนุกได้ทุกที่ที่อยู่ในเมือง ระบบจะสร้างจุดหมายที่เดินไปถึงได้จากตำแหน่งปัจจุบันโดยอัตโนมัติ โดยอ้างอิงจากข้อมูล GPS</p>
+          </details>
+          <details>
+            <summary>ใช้ปริมาณเน็ตและแบตเตอรี่มากแค่ไหน?</summary>
+            <p>เนื่องจากต้องดึงข้อมูลตำแหน่งต่อเนื่อง การเล่นเป็นเวลานานจึงทำให้แบตเตอรี่หมดเร็วขึ้น ส่วนปริมาณเน็ตส่วนใหญ่ใช้กับการแสดงแผนที่ ซึ่งไม่ได้มากเกินไป</p>
+          </details>
+          <details>
+            <summary>มีข้อควรระวังเพื่อเล่นอย่างปลอดภัยไหม?</summary>
+            <p>โปรดระมัดระวังอย่างยิ่งในการกดจอขณะเดิน กรุณาปฏิบัติตามกฎความปลอดภัยพื้นฐานในการเดินเล่นเสมอ เช่น หยุดยืนก่อนถึงทางม้าลาย และหลีกเลี่ยงทางเปลี่ยวยามค่ำคืนหรือพื้นที่ที่ไม่มีคน</p>
+          </details>
+          <details>
+            <summary>มีเวอร์ชัน Android ไหม?</summary>
+            <p>ขณะนี้กำลังรับสมัครผู้ทดสอบเพื่อเตรียมเผยแพร่บน Google Play คุณสามารถลงทะเบียนเป็นผู้ทดสอบได้จาก<a href="/th/tester-android">หน้านี้</a></p>
+          </details>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Final CTA ==================== -->
+    <section class="section cta-section" id="download">
+      <div class="container container--narrow">
+        <h2>มาเปลี่ยนการเดินเล่นให้เป็นการผจญภัยกันเถอะ</h2>
+        <p>ดาวน์โหลดเลยตอนนี้ แล้วก้าวออกไปสู่สถานที่ที่คุณไม่เคยรู้จัก</p>
+        <div class="hero__cta" style="justify-content: center;">
+          <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="ดาวน์โหลดบน App Store">
+            <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/th-th?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
+          </a>
+          <a class="btn" href="/th/tester-android" style="background:#fff;">Android (กำลังรับสมัครผู้ทดสอบ)</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Contact ==================== -->
+    <section class="section" id="contact">
+      <div class="container">
+        <h2 class="section__title">ติดต่อเรา</h2>
+        <p class="section__lead">ไม่ว่าจะเป็นการแจ้งบั๊ก ความคิดเห็น หรือการพูดคุยเรื่องความร่วมมือ ทักมาได้เลยตามสบาย</p>
+        <div class="contact-card">
+          <p>กรุณาติดต่อเราทางอีเมลผ่านปุ่มด้านล่าง</p>
+          <a class="btn btn--lg" href="mailto:akmatsutaiki@gmail.com?subject=%E3%80%90%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%A9%E3%83%BC%E3%82%BA%E3%80%91%E3%81%8A%E5%95%8F%E3%81%84%E5%90%88%E3%82%8F%E3%81%9B">
+            ติดต่อทางอีเมล
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Footer ==================== -->
+    <footer class="site-footer">
+      <div class="container">
+        <div class="site-footer__grid">
+          <div>
+            <div class="site-footer__brand">Explores</div>
+            <p class="site-footer__brand-line">เกมเดินสำรวจเมืองที่เปลี่ยนการเดินเล่นให้เป็นการผจญภัย<br />by Prokonjo</p>
+          </div>
+          <div class="site-footer__col">
+            <h4>เว็บไซต์</h4>
+            <ul>
+              <li><a href="#about">จุดเด่น</a></li>
+              <li><a href="#how">วิธีเล่น</a></li>
+              <li><a href="#awards">ผลงาน</a></li>
+              <li><a href="#faq">คำถามที่พบบ่อย</a></li>
+            </ul>
+          </div>
+          <div class="site-footer__col">
+            <h4>ข้อมูลผู้ดูแล</h4>
+            <ul>
+              <li><a href="/th/privacy-policy/">นโยบายความเป็นส่วนตัว</a></li>
+              <li><a href="#contact">ติดต่อเรา</a></li>
+              <li><a href="/th/tester-android">ผู้ทดสอบ Android</a></li>
+            </ul>
+          </div>
+        </div>
+        <nav class="lang-switch" aria-label="ภาษา / Language">
+          <span class="lang-switch__label">ภาษา</span>
+          <a href="/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/" hreflang="en" lang="en">English</a>
+          <a href="/zh/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/" hreflang="es" lang="es">Español</a>
+          <a href="/th/" hreflang="th" lang="th" class="is-current" aria-current="true">ไทย</a>
+        </nav>
+        <div class="site-footer__bottom">
+          <span>© 2024-2026 Prokonjo. All rights reserved.</span>
+          <div class="site-footer__social">
+            <a href="https://github.com/prokonjo-team" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+              <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      // Mobile menu toggle
+      (function() {
+        var btn = document.querySelector('.menu-btn');
+        var menu = document.getElementById('mobile-menu');
+        if (!btn || !menu) return;
+        btn.addEventListener('click', function() {
+          var open = menu.dataset.open === 'true';
+          menu.dataset.open = open ? 'false' : 'true';
+          btn.setAttribute('aria-expanded', String(!open));
+        });
+        // Close on link tap
+        menu.querySelectorAll('a').forEach(function(a) {
+          a.addEventListener('click', function() {
+            menu.dataset.open = 'false';
+            btn.setAttribute('aria-expanded', 'false');
+          });
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/th/privacy-policy/index.html
+++ b/th/privacy-policy/index.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="th">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>นโยบายความเป็นส่วนตัว｜Explores</title>
+    <meta name="description" content="นโยบายความเป็นส่วนตัวของ Explores เกี่ยวกับการจัดการข้อมูลตำแหน่งที่ตั้งและระยะเวลาการเก็บรักษาข้อมูล" />
+    <meta name="theme-color" content="#FACD00" />
+    <meta name="robots" content="noindex" />
+    <link rel="canonical" href="https://prokonjo.com/th/privacy-policy/" />
+    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/privacy-policy/" />
+    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/privacy-policy/" />
+    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/privacy-policy/" />
+    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/privacy-policy/" />
+    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/privacy-policy/" />
+    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/privacy-policy/" />
+    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/privacy-policy/" />
+    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/privacy-policy/" />
+    <link rel="icon" type="image/png" href="/assets/favicon.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/css/styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-P3YYZEG46Z');
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container site-header__inner">
+        <a class="site-header__brand" href="/th/" aria-label="หน้าแรก Explores">
+          <span class="site-header__brand-mark" aria-hidden="true">🧭</span>
+          <span>Explores</span>
+        </a>
+        <nav class="site-nav" aria-label="เมนูหลัก">
+          <a href="/th/#about">จุดเด่น</a>
+          <a href="/th/#how">วิธีเล่น</a>
+          <a href="/th/#awards">ผลงาน</a>
+          <a href="/th/#faq">คำถามที่พบบ่อย</a>
+          <a href="/th/#contact">ติดต่อเรา</a>
+        </nav>
+        <a class="btn site-header__cta" href="/th/#download" aria-label="ดาวน์โหลด">
+          <svg class="site-header__cta-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>
+          <span class="site-header__cta-label">ดาวน์โหลด</span>
+        </a>
+        <button class="menu-btn" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="เปิดเมนู">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+        </button>
+      </div>
+      <div id="mobile-menu" data-open="false">
+        <a href="/th/#about">จุดเด่น</a>
+        <a href="/th/#how">วิธีเล่น</a>
+        <a href="/th/#awards">ผลงาน</a>
+        <a href="/th/#faq">คำถามที่พบบ่อย</a>
+        <a href="/th/#contact">ติดต่อเรา</a>
+        <a href="/th/privacy-policy/">นโยบายความเป็นส่วนตัว</a>
+        <div class="mobile-menu__lang" aria-label="ภาษา / Language">
+          <a href="/privacy-policy/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/privacy-policy/" hreflang="en" lang="en">English</a>
+          <a href="/zh/privacy-policy/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/privacy-policy/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/privacy-policy/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/privacy-policy/" hreflang="es" lang="es">Español</a>
+          <a href="/th/privacy-policy/" hreflang="th" lang="th" class="is-current" aria-current="true">ไทย</a>
+        </div>
+      </div>
+    </header>
+
+    <section class="page-header">
+      <div class="container">
+        <h1>นโยบายความเป็นส่วนตัว</h1>
+        <p class="page-header__lead">เกี่ยวกับข้อมูลที่ Explores จัดการและวัตถุประสงค์ในการใช้งาน</p>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <article class="prose">
+          <p>นโยบายความเป็นส่วนตัวนี้ใช้กับแอปพลิเคชันบนมือถือ “Explores” (ต่อไปนี้เรียกว่า “แอปนี้”) ที่ Taiki Akamatsu (ต่อไปนี้เรียกว่า “ผู้ให้บริการ”) จัดเตรียมให้โดยไม่มีค่าใช้จ่าย บริการนี้ให้บริการบนพื้นฐานการใช้งาน “ตามสภาพที่เป็นอยู่”</p>
+
+          <h2>ข้อมูลที่เก็บรวบรวมและวัตถุประสงค์ในการใช้งาน</h2>
+          <p>แอปนี้อาจเก็บรวบรวมข้อมูลดังต่อไปนี้เมื่อทำการดาวน์โหลดและใช้งาน</p>
+          <ul>
+            <li>ที่อยู่ IP ของอุปกรณ์</li>
+            <li>หน้าที่เข้าชมภายในแอปนี้ วันและเวลาที่เข้าชม และระยะเวลาที่ใช้</li>
+            <li>เวลาที่ใช้งานแอปนี้</li>
+            <li>ระบบปฏิบัติการ (OS) ของอุปกรณ์มือถือที่ใช้งาน</li>
+          </ul>
+
+          <p>แอปนี้เก็บรวบรวมข้อมูลตำแหน่งที่ตั้งของอุปกรณ์ ข้อมูลตำแหน่งที่ตั้งจะถูกใช้เพื่อระบุตำแหน่งทางภูมิศาสตร์โดยประมาณ และนำไปใช้ในวัตถุประสงค์ดังต่อไปนี้</p>
+          <ul>
+            <li><strong>บริการตามตำแหน่งที่ตั้ง</strong>: การนำเสนอเนื้อหาที่ปรับให้เหมาะกับผู้ใช้ คำแนะนำที่มีความเกี่ยวข้องสูง และฟังก์ชันที่อิงตามตำแหน่งที่ตั้ง</li>
+            <li><strong>การวิเคราะห์และปรับปรุง</strong>: การวิเคราะห์พฤติกรรมของผู้ใช้และปรับปรุงประสิทธิภาพโดยรวมของแอปนี้ โดยอาศัยข้อมูลตำแหน่งที่ตั้งซึ่งรวบรวมและทำให้ไม่ระบุตัวตน</li>
+            <li><strong>บริการของบุคคลที่สาม</strong>: อาจมีการส่งข้อมูลตำแหน่งที่ตั้งซึ่งทำให้ไม่ระบุตัวตนไปยังบริการภายนอกที่ช่วยปรับปรุงแอปนี้และปรับเนื้อหาที่ให้บริการให้เหมาะสมที่สุด</li>
+          </ul>
+
+          <p>ผู้ให้บริการอาจใช้ข้อมูลที่ได้รับเพื่อวัตถุประสงค์ในการติดต่อกับคุณ (เช่น ประกาศสำคัญ การแจ้งเตือนที่จำเป็น การแจ้งข้อมูลทางการตลาด เป็นต้น) นอกจากนี้ เพื่อมอบประสบการณ์ที่ดียิ่งขึ้น อาจมีการขอให้คุณให้ข้อมูลที่สามารถระบุตัวบุคคลได้ ซึ่งข้อมูลดังกล่าวจะถูกใช้และจัดเก็บตามที่ระบุไว้ในนโยบายนี้</p>
+
+          <h2>การเปิดเผยข้อมูลแก่บุคคลที่สาม</h2>
+          <p>เราจะส่งเฉพาะข้อมูลที่รวบรวมและทำให้ไม่ระบุตัวตนไปยังบริการภายนอกเป็นระยะเท่านั้น ผู้ให้บริการอาจแบ่งปันข้อมูลกับบุคคลที่สามตามวิธีการที่ระบุไว้ในนโยบายนี้</p>
+
+          <p>แอปนี้ใช้บริการของบุคคลที่สามซึ่งมีนโยบายความเป็นส่วนตัวของตนเอง โปรดดูนโยบายความเป็นส่วนตัวของบริการบุคคลที่สามที่ใช้งานได้จากด้านล่าง</p>
+          <ul>
+            <li><a href="https://www.google.com/policies/privacy/" target="_blank" rel="noopener noreferrer">Google Play Services</a></li>
+          </ul>
+
+          <p>ผู้ให้บริการอาจเปิดเผยข้อมูลที่ผู้ใช้ให้มาและข้อมูลที่เก็บรวบรวมโดยอัตโนมัติ ในกรณีที่เข้าข่ายข้อใดข้อหนึ่งดังต่อไปนี้</p>
+          <ul>
+            <li>เมื่อกฎหมายกำหนด เช่น การตอบสนองต่อหมายเรียกหรือกระบวนการทางกฎหมายในลักษณะเดียวกัน</li>
+            <li>เมื่อพิจารณาโดยสุจริตแล้วว่าจำเป็น เพื่อปกป้องสิทธิของผู้ให้บริการ ความปลอดภัยของผู้ใช้หรือบุคคลที่สาม การตรวจสอบการกระทำที่ไม่ถูกต้อง หรือการตอบสนองต่อคำร้องขอของรัฐบาล</li>
+            <li>เมื่อเป็นผู้ให้บริการที่เชื่อถือได้ซึ่งปฏิบัติงานในนามของผู้ให้บริการ และได้ตกลงว่าจะไม่ใช้ข้อมูลโดยอิสระและจะปฏิบัติตามนโยบายนี้</li>
+          </ul>
+
+          <h2>เกี่ยวกับการเลือกไม่เข้าร่วม (Opt-out)</h2>
+          <p>คุณสามารถหยุดการเก็บรวบรวมข้อมูลทั้งหมดได้โดยการถอนการติดตั้งแอปนี้ โปรดใช้ขั้นตอนการถอนการติดตั้งมาตรฐานของอุปกรณ์หรือสโตร์ของคุณ</p>
+
+          <h2>ระยะเวลาการเก็บรักษาข้อมูล</h2>
+          <p>ผู้ให้บริการจะเก็บรักษาข้อมูลที่ผู้ใช้ให้มาตลอดระยะเวลาที่ใช้งานแอปนี้และตลอดระยะเวลาที่พิจารณาแล้วว่าสมเหตุสมผล หากคุณต้องการให้ลบข้อมูลที่ให้ไว้ผ่านแอปนี้ โปรดติดต่อมาที่ <a href="mailto:akmatsutaiki@gmail.com">akmatsutaiki@gmail.com</a> เราจะดำเนินการภายในระยะเวลาที่สมเหตุสมผล</p>
+
+          <h2>เกี่ยวกับการใช้งานโดยเด็ก</h2>
+          <p>ผู้ให้บริการจะไม่จงใจเก็บรวบรวมข้อมูลหรือทำการตลาดกับเด็กที่มีอายุต่ำกว่า 13 ปีผ่านแอปนี้</p>
+          <p>แอปนี้ไม่ได้มีไว้สำหรับเด็กอายุต่ำกว่า 13 ปี หากพบว่าได้รับข้อมูลส่วนบุคคลจากเด็กที่มีอายุต่ำกว่า 13 ปี เราจะลบข้อมูลดังกล่าวออกจากเซิร์ฟเวอร์ทันที หากท่านผู้ปกครองพบว่าบุตรหลานได้ให้ข้อมูลส่วนบุคคลไว้ โปรดติดต่อมาที่ <a href="mailto:akmatsutaiki@gmail.com">akmatsutaiki@gmail.com</a></p>
+
+          <h2>ความปลอดภัย</h2>
+          <p>ผู้ให้บริการมุ่งมั่นที่จะรักษาความลับของข้อมูลของคุณ เราได้ดำเนินมาตรการรักษาความปลอดภัยทั้งทางกายภาพ ทางอิเล็กทรอนิกส์ และทางขั้นตอน เพื่อปกป้องข้อมูลที่ประมวลผลและจัดเก็บ</p>
+
+          <h2>การเปลี่ยนแปลงนโยบายนี้</h2>
+          <p>นโยบายความเป็นส่วนตัวนี้อาจมีการปรับปรุงเป็นครั้งคราวตามความจำเป็น ผู้ให้บริการจะแจ้งเนื้อหาที่เปลี่ยนแปลงโดยการปรับปรุงหน้านี้ การใช้งานอย่างต่อเนื่องจะถือว่าคุณยินยอมต่อการเปลี่ยนแปลงทั้งหมด ดังนั้นโปรดตรวจสอบเป็นระยะ</p>
+
+          <p>วันที่นโยบายความเป็นส่วนตัวนี้มีผลบังคับใช้: <strong>2024-05-06</strong></p>
+
+          <h2>เกี่ยวกับการยินยอม</h2>
+          <p>การใช้งานแอปนี้ถือว่าคุณยินยอมให้มีการประมวลผลข้อมูลของคุณตามนโยบายความเป็นส่วนตัวนี้</p>
+
+          <h2>ติดต่อเรา</h2>
+          <p>หากคุณมีคำถามเกี่ยวกับความเป็นส่วนตัวขณะใช้งานแอปนี้ หรือมีคำถามเกี่ยวกับนโยบายนี้ โปรดติดต่อทางอีเมลมาที่ <a href="mailto:akmatsutaiki@gmail.com">akmatsutaiki@gmail.com</a></p>
+
+          <hr />
+          <p style="font-size: 0.86rem; color: var(--c-text-muted);">นโยบายนี้จัดทำขึ้นโดยใช้ <a href="https://app-privacy-policy-generator.nisrulz.com/" target="_blank" rel="noopener noreferrer">App Privacy Policy Generator</a></p>
+        </article>
+      </div>
+    </section>
+
+    <footer class="site-footer">
+      <div class="container">
+        <div class="site-footer__grid">
+          <div>
+            <div class="site-footer__brand">Explores</div>
+            <p class="site-footer__brand-line">เกมเดินสำรวจเมืองที่เปลี่ยนการเดินเล่นให้เป็นการผจญภัย<br />by Prokonjo</p>
+          </div>
+          <div class="site-footer__col">
+            <h4>เว็บไซต์</h4>
+            <ul>
+              <li><a href="/th/#about">จุดเด่น</a></li>
+              <li><a href="/th/#how">วิธีเล่น</a></li>
+              <li><a href="/th/#awards">ผลงาน</a></li>
+              <li><a href="/th/#faq">คำถามที่พบบ่อย</a></li>
+            </ul>
+          </div>
+          <div class="site-footer__col">
+            <h4>ข้อมูลการดำเนินงาน</h4>
+            <ul>
+              <li><a href="/th/privacy-policy/">นโยบายความเป็นส่วนตัว</a></li>
+              <li><a href="/th/#contact">ติดต่อเรา</a></li>
+              <li><a href="/th/tester-android/">ผู้ทดสอบ Android</a></li>
+            </ul>
+          </div>
+        </div>
+        <nav class="lang-switch" aria-label="ภาษา / Language">
+          <span class="lang-switch__label">ภาษา</span>
+          <a href="/privacy-policy/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/privacy-policy/" hreflang="en" lang="en">English</a>
+          <a href="/zh/privacy-policy/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/privacy-policy/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/privacy-policy/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/privacy-policy/" hreflang="es" lang="es">Español</a>
+          <a href="/th/privacy-policy/" hreflang="th" lang="th" class="is-current" aria-current="true">ไทย</a>
+        </nav>
+        <div class="site-footer__bottom">
+          <span>© 2024-2026 Prokonjo. All rights reserved.</span>
+          <div class="site-footer__social">
+            <a href="https://github.com/prokonjo-team" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+              <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      (function() {
+        var btn = document.querySelector('.menu-btn');
+        var menu = document.getElementById('mobile-menu');
+        if (!btn || !menu) return;
+        btn.addEventListener('click', function() {
+          var open = menu.dataset.open === 'true';
+          menu.dataset.open = open ? 'false' : 'true';
+          btn.setAttribute('aria-expanded', String(!open));
+        });
+        menu.querySelectorAll('a').forEach(function(a) {
+          a.addEventListener('click', function() {
+            menu.dataset.open = 'false';
+            btn.setAttribute('aria-expanded', 'false');
+          });
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/th/tester-android/index.html
+++ b/th/tester-android/index.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="th">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>กำลังรับสมัครผู้ทดสอบ Android｜Explores</title>
+    <meta name="description" content="หน้ารับสมัครผู้ทดสอบ Android ของ Explores ทำได้ใน 3 ขั้นตอน คือ ลงทะเบียน Google Groups → ติดตั้งแอป → เปิดแอป" />
+    <meta name="theme-color" content="#FACD00" />
+    <meta name="robots" content="noindex" />
+    <link rel="canonical" href="https://prokonjo.com/th/tester-android/" />
+    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/tester-android/" />
+    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/tester-android/" />
+    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/tester-android/" />
+    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/tester-android/" />
+    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/tester-android/" />
+    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/tester-android/" />
+    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/tester-android/" />
+    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/tester-android/" />
+    <link rel="icon" type="image/png" href="/assets/favicon.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/css/styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-P3YYZEG46Z');
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container site-header__inner">
+        <a class="site-header__brand" href="/th/" aria-label="หน้าแรก Explores">
+          <span class="site-header__brand-mark" aria-hidden="true">🧭</span>
+          <span>Explores</span>
+        </a>
+        <nav class="site-nav" aria-label="เมนูหลัก">
+          <a href="/th/#about">จุดเด่น</a>
+          <a href="/th/#how">วิธีเล่น</a>
+          <a href="/th/#awards">ผลงาน</a>
+          <a href="/th/#faq">คำถามที่พบบ่อย</a>
+          <a href="/th/#contact">ติดต่อเรา</a>
+        </nav>
+        <a class="btn site-header__cta" href="/th/#download" aria-label="ดาวน์โหลด">
+          <svg class="site-header__cta-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>
+          <span class="site-header__cta-label">ดาวน์โหลด</span>
+        </a>
+        <button class="menu-btn" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="เปิดเมนู">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+        </button>
+      </div>
+      <div id="mobile-menu" data-open="false">
+        <a href="/th/#about">จุดเด่น</a>
+        <a href="/th/#how">วิธีเล่น</a>
+        <a href="/th/#awards">ผลงาน</a>
+        <a href="/th/#faq">คำถามที่พบบ่อย</a>
+        <a href="/th/#contact">ติดต่อเรา</a>
+        <a href="/th/privacy-policy/">นโยบายความเป็นส่วนตัว</a>
+        <div class="mobile-menu__lang" aria-label="ภาษา / Language">
+          <a href="/tester-android/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/tester-android/" hreflang="en" lang="en">English</a>
+          <a href="/zh/tester-android/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/tester-android/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/tester-android/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/tester-android/" hreflang="es" lang="es">Español</a>
+          <a href="/th/tester-android/" hreflang="th" lang="th" class="is-current" aria-current="true">ไทย</a>
+        </div>
+      </div>
+    </header>
+
+    <section class="page-header">
+      <div class="container">
+        <h1>กำลังรับสมัครผู้ทดสอบ Android</h1>
+        <p class="page-header__lead">เรากำลังมองหาผู้ที่จะมาเล่น Explores บน Android ก่อนใคร เพื่อเตรียมเปิดตัวบน Google Play สมัครเข้าร่วมได้เลยใน 3 ขั้นตอน!</p>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container container--narrow">
+        <div class="callout" style="margin-bottom: 2.5rem;">
+          <span class="callout__icon" aria-hidden="true">💡</span>
+          <div class="callout__body">
+            <strong>สิ่งที่เราขอความร่วมมือจากผู้ทดสอบ</strong>
+            <p>มี 3 อย่าง คือ ติดตั้งแอป Android (จำเป็น) / เปิดแอป (จำเป็น) / ตอบแบบสอบถาม (ไม่บังคับ)</p>
+          </div>
+        </div>
+
+        <div class="tester-step">
+          <div class="tester-step__num">1</div>
+          <div class="tester-step__body">
+            <h3>ลงทะเบียน Google Groups</h3>
+            <p>โปรดเข้าร่วม Google Groups จากลิงก์ด้านล่าง หากยังไม่ได้เข้า Google Groups สำหรับผู้ทดสอบ จะไม่สามารถแสดงแอปบน Google Play ได้</p>
+            <a class="btn" href="https://groups.google.com/search?q=explores_tester&inOrg=false" target="_blank" rel="noopener noreferrer">ลงทะเบียน Google Groups</a>
+            <div class="tester-step__images">
+              <img src="/tester-android/imgs/1.png" alt="ขั้นตอนการลงทะเบียน Google Groups 1" loading="lazy" />
+              <img src="/tester-android/imgs/2.png" alt="ขั้นตอนการลงทะเบียน Google Groups 2" loading="lazy" />
+            </div>
+          </div>
+        </div>
+
+        <div class="tester-step">
+          <div class="tester-step__num">2</div>
+          <div class="tester-step__body">
+            <h3>ติดตั้งแอป</h3>
+            <p>เมื่อการลงทะเบียน Google Groups มีผลแล้ว โปรดติดตั้งแอปบน Google Play จากลิงก์ด้านล่าง</p>
+            <a class="btn" href="https://play.google.com/store/apps/details?id=com.prokonjo.explores" target="_blank" rel="noopener noreferrer">ติดตั้งบน Google Play</a>
+            <p style="margin-top: 1rem; font-size: 0.92rem;">หากปรากฏข้อความว่า "ไม่พบ URL ที่ร้องขอบนเซิร์ฟเวอร์นี้" อาจเป็นเพราะการลงทะเบียน Google Groups ยังไม่มีผล โปรดรอสักครู่แล้วลองใหม่อีกครั้ง</p>
+          </div>
+        </div>
+
+        <div class="tester-step">
+          <div class="tester-step__num">3</div>
+          <div class="tester-step__body">
+            <h3>เปิดแอป</h3>
+            <p>หลังติดตั้งแล้ว เมื่อเปิดแอปขึ้นมาสักครั้ง การลงทะเบียนเป็นผู้ทดสอบก็จะเสร็จสมบูรณ์</p>
+            <div class="callout">
+              <span class="callout__icon" aria-hidden="true">⚠️</span>
+              <div class="callout__body">
+                <strong>ขอความร่วมมือ</strong>
+                <p>เมื่อติดตั้งแล้ว โปรดอย่าลบแอปออก หากถอนการติดตั้ง คุณจะถูกถอดออกจากการเป็นผู้ทดสอบ</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="tester-step">
+          <div class="tester-step__num">+</div>
+          <div class="tester-step__body">
+            <h3>(ไม่บังคับ) ช่วยตอบแบบสอบถามด้วยนะ</h3>
+            <p>หากคุณช่วยส่งความคิดเห็นเกี่ยวกับประสบการณ์การใช้งาน ก็จะเป็นประโยชน์ต่อการปรับปรุงแอปเป็นอย่างมาก</p>
+            <a class="btn btn--secondary" href="https://docs.google.com/forms/d/1sWQDp1t_8PnzxENLO9BHw-IYn2yrNgumjZMQWQWam8I" target="_blank" rel="noopener noreferrer">ตอบแบบสอบถาม</a>
+          </div>
+        </div>
+
+        <div style="text-align: center; margin-top: 3rem;">
+          <a class="btn btn--ghost" href="/th/">กลับหน้าแรก</a>
+        </div>
+      </div>
+    </section>
+
+    <footer class="site-footer">
+      <div class="container">
+        <div class="site-footer__grid">
+          <div>
+            <div class="site-footer__brand">Explores</div>
+            <p class="site-footer__brand-line">เกมเดินเที่ยวเมืองที่เปลี่ยนการเดินเล่นให้เป็นการผจญภัย<br />by Prokonjo</p>
+          </div>
+          <div class="site-footer__col">
+            <h4>เว็บไซต์</h4>
+            <ul>
+              <li><a href="/th/#about">จุดเด่น</a></li>
+              <li><a href="/th/#how">วิธีเล่น</a></li>
+              <li><a href="/th/#awards">ผลงาน</a></li>
+              <li><a href="/th/#faq">คำถามที่พบบ่อย</a></li>
+            </ul>
+          </div>
+          <div class="site-footer__col">
+            <h4>ข้อมูลผู้ให้บริการ</h4>
+            <ul>
+              <li><a href="/th/privacy-policy/">นโยบายความเป็นส่วนตัว</a></li>
+              <li><a href="/th/#contact">ติดต่อเรา</a></li>
+              <li><a href="/th/tester-android/">ผู้ทดสอบ Android</a></li>
+            </ul>
+          </div>
+        </div>
+        <nav class="lang-switch" aria-label="ภาษา / Language">
+          <span class="lang-switch__label">ภาษา</span>
+          <a href="/tester-android/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/tester-android/" hreflang="en" lang="en">English</a>
+          <a href="/zh/tester-android/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+          <a href="/fr/tester-android/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/tester-android/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/tester-android/" hreflang="es" lang="es">Español</a>
+          <a href="/th/tester-android/" hreflang="th" lang="th" class="is-current" aria-current="true">ไทย</a>
+        </nav>
+        <div class="site-footer__bottom">
+          <span>© 2024-2026 Prokonjo. All rights reserved.</span>
+          <div class="site-footer__social">
+            <a href="https://github.com/prokonjo-team" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+              <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      (function() {
+        var btn = document.querySelector('.menu-btn');
+        var menu = document.getElementById('mobile-menu');
+        if (!btn || !menu) return;
+        btn.addEventListener('click', function() {
+          var open = menu.dataset.open === 'true';
+          menu.dataset.open = open ? 'false' : 'true';
+          btn.setAttribute('aria-expanded', String(!open));
+        });
+        menu.querySelectorAll('a').forEach(function(a) {
+          a.addEventListener('click', function() {
+            menu.dataset.open = 'false';
+            btn.setAttribute('aria-expanded', 'false');
+          });
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/zh/index.html
+++ b/zh/index.html
@@ -1,0 +1,450 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>Explores｜把散步變成冒險的街頭探索遊戲</title>
+    <meta name="description" content="把散步變成冒險的街頭探索遊戲「Explores」。以照片為提示，走進陌生的地方一步步抵達目的地。一局約 15 分鐘、免費、無內購。" />
+    <meta name="author" content="Prokonjo" />
+    <meta name="theme-color" content="#FACD00" />
+    <link rel="canonical" href="https://prokonjo.com/zh/" />
+
+    <!-- hreflang alternates -->
+    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/" />
+    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/" />
+    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/" />
+    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/" />
+    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/" />
+    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/" />
+    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/" />
+    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/" />
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Explores" />
+    <meta property="og:title" content="Explores｜把散步變成冒險的街頭探索遊戲" />
+    <meta property="og:description" content="以照片為提示，走進陌生的地方一步步抵達目的地的街頭探索遊戲。一局約 15 分鐘、免費、無內購。" />
+    <meta property="og:url" content="https://prokonjo.com/zh/" />
+    <meta property="og:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+    <meta property="og:image:type" content="image/jpeg" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta property="og:locale" content="zh_TW" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Explores｜把散步變成冒險的街頭探索遊戲" />
+    <meta name="twitter:description" content="以照片為提示，走進陌生的地方一步步抵達目的地的街頭探索遊戲。一局約 15 分鐘、免費、無內購。" />
+    <meta name="twitter:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" href="/assets/favicon.png" />
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+
+    <link rel="stylesheet" href="/css/styles.css" />
+
+    <!-- Structured data -->
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "MobileApplication",
+        "name": "Explores",
+        "description": "把散步變成冒險的街頭探索遊戲。以照片為提示，走進陌生的地方一步步抵達目的地，一局約 15 分鐘的探索體驗。",
+        "url": "https://prokonjo.com/",
+        "applicationCategory": "GameApplication",
+        "operatingSystem": "iOS",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "JPY"
+        },
+        "publisher": {
+          "@type": "Organization",
+          "name": "Prokonjo",
+          "url": "https://prokonjo.com/"
+        }
+      }
+    </script>
+
+    <!-- Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-P3YYZEG46Z');
+    </script>
+  </head>
+  <body>
+    <!-- ==================== Header ==================== -->
+    <header class="site-header">
+      <div class="container site-header__inner">
+        <a class="site-header__brand" href="#top" aria-label="Explores 首頁">
+          <span class="site-header__brand-mark" aria-hidden="true">🧭</span>
+          <span>Explores</span>
+        </a>
+        <nav class="site-nav" aria-label="主選單">
+          <a href="#about">特色</a>
+          <a href="#how">玩法</a>
+          <a href="#awards">獲獎紀錄</a>
+          <a href="#faq">FAQ</a>
+          <a href="#contact">聯絡我們</a>
+        </nav>
+        <a class="btn site-header__cta" href="#download" aria-label="下載">
+          <svg class="site-header__cta-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>
+          <span class="site-header__cta-label">下載</span>
+        </a>
+        <button class="menu-btn" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="開啟選單">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+        </button>
+      </div>
+      <div id="mobile-menu" data-open="false">
+        <a href="#about">特色</a>
+        <a href="#how">玩法</a>
+        <a href="#awards">獲獎紀錄</a>
+        <a href="#faq">FAQ</a>
+        <a href="#contact">聯絡我們</a>
+        <a href="/zh/privacy-policy/">隱私權政策</a>
+        <div class="mobile-menu__lang" aria-label="語言 / Language">
+          <a href="/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/" hreflang="en" lang="en">English</a>
+          <a href="/zh/" hreflang="zh-Hant" lang="zh-Hant" class="is-current" aria-current="true">繁體中文</a>
+          <a href="/fr/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/" hreflang="es" lang="es">Español</a>
+          <a href="/th/" hreflang="th" lang="th">ไทย</a>
+        </div>
+      </div>
+    </header>
+
+    <!-- ==================== Hero ==================== -->
+    <section class="hero" id="top">
+      <div class="container hero__inner">
+        <div>
+          <span class="hero__eyebrow">🧭 街頭探索遊戲</span>
+          <h1 class="hero__title">把散步，變成<em>冒險</em>。</h1>
+          <p class="hero__sub">
+            以照片為提示，走進陌生的地方一步步抵達目的地。<br />
+            一局約 15 分鐘。免費、無內購的街頭探索遊戲。
+          </p>
+          <div class="hero__cta">
+            <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="從 App Store 下載">
+              <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/zh-tw?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
+            </a>
+            <a class="btn btn--secondary" href="/zh/tester-android">Android（招募測試者中）</a>
+          </div>
+          <p class="hero__note">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>
+            免費 ／ 無內購 ／ 無廣告
+          </p>
+        </div>
+        <div class="hero__visual">
+          <img src="/assets/img/game-desc.jpg" alt="Explores 的遊玩示意圖" width="1200" height="676" />
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Empathy ==================== -->
+    <section class="section section--alt" id="about">
+      <div class="container">
+        <h2 class="section__title">這樣的散步，你是不是也膩了？</h2>
+        <p class="section__lead">想為了運動多走幾步，每天卻都是同一條路，實在很難堅持下去。<br />如果有個「值得走出門的理由」，或許就能多走一陣子。</p>
+        <div class="card-grid">
+          <div class="empathy-card">
+            <div class="empathy-card__icon" aria-hidden="true">🛣️</div>
+            <h3>每天同一條路，走到膩</h3>
+            <p>家裡和車站來回往返，不知不覺就低頭走完，根本沒在看風景。</p>
+          </div>
+          <div class="empathy-card">
+            <div class="empathy-card__icon" aria-hidden="true">📉</div>
+            <h3>養不成習慣，撐不久</h3>
+            <p>心裡想著「來走走吧」，結果三天就忘得一乾二淨。</p>
+          </div>
+          <div class="empathy-card">
+            <div class="empathy-card__icon" aria-hidden="true">🤔</div>
+            <h3>沒有走路的目標</h3>
+            <p>只是為了運動而走，動力怎麼樣都提不起來。</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Value ==================== -->
+    <section class="section">
+      <div class="container">
+        <h2 class="section__title">有了 Explores，<br />散步就成了冒險。</h2>
+        <p class="section__lead">只憑一張照片提示，前往陌生的地方。<br />每次都是不同的目的地，15 分鐘就能玩完。「走出門的理由」，就在這裡。</p>
+        <div class="card-grid">
+          <div class="value-card">
+            <div class="value-card__badge">01</div>
+            <h3>每次都是不同的目的地</h3>
+            <p>依你選的時間，每一局都隨機決定目的地，永遠不會在同一個地方走到膩。</p>
+          </div>
+          <div class="value-card">
+            <div class="value-card__badge">02</div>
+            <h3>照片提示帶來冒險感</h3>
+            <p>不看地圖，只憑目的地周邊的照片往前走。一句「那棟建築好像在哪見過⋯」就是冒險的開始。</p>
+          </div>
+          <div class="value-card">
+            <div class="value-card__badge">03</div>
+            <h3>15 分鐘玩完一局</h3>
+            <p>下班路上、休息空檔、假日散步。想玩就開始，想停就收手，輕鬆零負擔。</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== How ==================== -->
+    <section class="section section--surface" id="how">
+      <div class="container">
+        <h2 class="section__title">玩法只要 3 步驟</h2>
+        <p class="section__lead">從打開 App 到走上街頭，只要 30 秒。</p>
+        <div class="steps">
+          <div class="step">
+            <div class="step__num">1</div>
+            <img class="step__img" src="/assets/img/game-play0.png" alt="時間選擇畫面" loading="lazy" />
+            <h3>選擇時間</h3>
+            <p>選一段想走的時間，「15 分鐘」「30 分鐘」⋯⋯依當下的心情自由決定。</p>
+          </div>
+          <div class="step">
+            <div class="step__num">2</div>
+            <img class="step__img" src="/assets/img/game-play1.png" alt="確認目的地周邊照片與地圖的畫面" loading="lazy" />
+            <h3>記住目的地</h3>
+            <p>遊戲開始前，先把目的地周邊的照片與地圖看仔細。一旦開始，它們就會被藏起來。</p>
+          </div>
+          <div class="step">
+            <div class="step__num">3</div>
+            <img class="step__img" src="/assets/img/game-play2.png" alt="探索中的遊戲畫面" loading="lazy" />
+            <h3>憑記憶往前走</h3>
+            <p>只靠剩餘時間與距離，朝目的地前進。「啊，就是那張照片裡的景色！」</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Video ==================== -->
+    <section class="section">
+      <div class="container">
+        <h2 class="section__title">用影片認識 Explores</h2>
+        <p class="section__lead">一起來看看實際的遊玩畫面與街頭散步的樣子吧。</p>
+        <div class="video-wrap">
+          <iframe src="https://www.youtube.com/embed/ldIJdk3zwHY?si=jwntDJV8pnRAHKio" title="Explores 玩法介紹影片" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Awards ==================== -->
+    <section class="section section--alt" id="awards">
+      <div class="container">
+        <h2 class="section__title">獲獎紀錄</h2>
+        <p class="section__lead">從學生時代一路累積至今的競賽成績。</p>
+        <div class="awards">
+          <article class="award">
+            <img src="/assets/img/award-gikuhaku.jpg" alt="技育博 企業獎 得獎" loading="lazy" />
+            <div class="award__body">
+              <span class="award__tag">企業獎</span>
+              <h3>技育博</h3>
+              <p>在 Supporterz 主辦的技育博中，Explores 榮獲企業獎。</p>
+              <a class="award__link" href="https://x.com/geek_pjt/status/1789225529109057540" target="_blank" rel="noopener noreferrer">查看得獎貼文 →</a>
+            </div>
+          </article>
+          <article class="award">
+            <img src="/assets/img/award-wakayama.jpg" alt="和歌山創新程式設計競賽 最優秀獎 得獎" loading="lazy" />
+            <div class="award__body">
+              <span class="award__tag">最優秀獎</span>
+              <h3>和歌山創新程式設計競賽</h3>
+              <p>以解決和歌山在地課題的手機 App 企劃，榮獲最優秀獎。</p>
+              <a class="award__link" href="https://wakayama-innovation-lab.relic.co.jp/" target="_blank" rel="noopener noreferrer">查看主辦資訊 →</a>
+            </div>
+          </article>
+          <article class="award">
+            <img src="/assets/img/award-iizuka.jpg" alt="e-ZUKA 智慧 App 競賽 2023 市長獎 得獎" loading="lazy" />
+            <div class="award__body">
+              <span class="award__tag">市長獎 + 企業獎</span>
+              <h3>e-ZUKA 智慧 App 競賽 2023</h3>
+              <p>在福岡縣飯塚市主辦的競賽中，同時拿下飯塚市長獎與企業獎。</p>
+              <a class="award__link" href="http://e-zuka.info/2023/resurt.html" target="_blank" rel="noopener noreferrer">查看比賽結果 →</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Members ==================== -->
+    <section class="section" id="members">
+      <div class="container">
+        <h2 class="section__title">開發團隊</h2>
+        <p class="section__lead">一支認真把「讓散步變成冒險」做出來的 4 人團隊。</p>
+        <div class="members">
+          <div class="member">
+            <img src="/assets/img/member-akamatsu.png" alt="赤松汰輝" loading="lazy" width="96" height="96" />
+            <h3>赤松汰輝</h3>
+            <p>代表 / 工程師</p>
+            <div class="member__links">
+              <a href="https://www.wantedly.com/id/akamatsu_taiki" target="_blank" rel="noopener noreferrer" aria-label="Wantedly 個人檔案">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3a14 14 0 010 18M12 3a14 14 0 000 18"/></svg>
+              </a>
+              <a href="https://github.com/Taiki-sub" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+              </a>
+            </div>
+          </div>
+          <div class="member">
+            <img src="/assets/img/member-chang.png" alt="張珠煐" loading="lazy" width="96" height="96" />
+            <h3>張珠煐</h3>
+            <p>設計師</p>
+          </div>
+          <div class="member">
+            <img src="/assets/img/siteTop4.jpg" alt="楠本健人" loading="lazy" width="96" height="96" />
+            <h3>楠本健人</h3>
+            <p>設計師</p>
+          </div>
+          <div class="member">
+            <img src="/assets/img/member-hayashi.png" alt="林慎一郎" loading="lazy" width="96" height="96" />
+            <h3>林慎一郎</h3>
+            <p>工程師</p>
+            <div class="member__links">
+              <a href="https://www.github.com/hashin2425" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+                <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== FAQ ==================== -->
+    <section class="section section--surface" id="faq">
+      <div class="container">
+        <h2 class="section__title">常見問題</h2>
+        <p class="section__lead">把開玩前你可能在意的問題整理在這裡。</p>
+        <div class="faq">
+          <details>
+            <summary>真的免費嗎？有任何內購嗎？</summary>
+            <p>完全免費。沒有任何轉蛋、訂閱等內購項目。目前也不會顯示任何廣告。</p>
+          </details>
+          <details>
+            <summary>玩一局要多久？</summary>
+            <p>可從 15 分鐘、20 分鐘、30 分鐘等選項中，依當下心情自由選擇。無論是短暫的空檔，還是想盡情走的假日，都能對應。</p>
+          </details>
+          <details>
+            <summary>在什麼地方可以玩？</summary>
+            <p>只要在街區內，基本上到哪都能玩。系統會依 GPS 資訊，自動生成從你目前位置走得到的目的地範圍。</p>
+          </details>
+          <details>
+            <summary>數據用量與電池消耗大概多少？</summary>
+            <p>由於會持續取得定位資訊，長時間遊玩時電池確實比較容易耗電。數據用量主要來自地圖顯示，並不會太龐大。</p>
+          </details>
+          <details>
+            <summary>安全遊玩有哪些注意事項？</summary>
+            <p>請務必避免邊走邊操作手機。過斑馬線前先停下腳步、避開夜路與人煙稀少的區域等等，散步時的基本安全守則請一定要遵守。</p>
+          </details>
+          <details>
+            <summary>有 Android 版嗎？</summary>
+            <p>目前正為了在 Google Play 上架而招募測試者中。歡迎從<a href="/zh/tester-android">這個頁面</a>登錄成為測試者。</p>
+          </details>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Final CTA ==================== -->
+    <section class="section cta-section" id="download">
+      <div class="container container--narrow">
+        <h2>來吧，把散步變成冒險。</h2>
+        <p>現在就下載，踏出走向陌生地方的第一步。</p>
+        <div class="hero__cta" style="justify-content: center;">
+          <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="從 App Store 下載">
+            <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/zh-tw?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
+          </a>
+          <a class="btn" href="/zh/tester-android" style="background:#fff;">Android（招募測試者中）</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Contact ==================== -->
+    <section class="section" id="contact">
+      <div class="container">
+        <h2 class="section__title">聯絡我們</h2>
+        <p class="section__lead">無論是錯誤回報、心得感想，還是合作洽談，都歡迎與我們聯繫。</p>
+        <div class="contact-card">
+          <p>請透過下方按鈕以電子郵件與我們聯絡。</p>
+          <a class="btn btn--lg" href="mailto:akmatsutaiki@gmail.com?subject=%E3%80%90%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%A9%E3%83%BC%E3%82%BA%E3%80%91%E3%81%8A%E5%95%8F%E3%81%84%E5%90%88%E3%82%8F%E3%81%9B">
+            以電子郵件聯絡
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- ==================== Footer ==================== -->
+    <footer class="site-footer">
+      <div class="container">
+        <div class="site-footer__grid">
+          <div>
+            <div class="site-footer__brand">Explores</div>
+            <p class="site-footer__brand-line">把散步變成冒險的街頭探索遊戲。<br />by Prokonjo</p>
+          </div>
+          <div class="site-footer__col">
+            <h4>網站</h4>
+            <ul>
+              <li><a href="#about">特色</a></li>
+              <li><a href="#how">玩法</a></li>
+              <li><a href="#awards">獲獎紀錄</a></li>
+              <li><a href="#faq">FAQ</a></li>
+            </ul>
+          </div>
+          <div class="site-footer__col">
+            <h4>營運資訊</h4>
+            <ul>
+              <li><a href="/zh/privacy-policy/">隱私權政策</a></li>
+              <li><a href="#contact">聯絡我們</a></li>
+              <li><a href="/zh/tester-android">Android 測試者</a></li>
+            </ul>
+          </div>
+        </div>
+        <nav class="lang-switch" aria-label="語言 / Language">
+          <span class="lang-switch__label">語言</span>
+          <a href="/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/" hreflang="en" lang="en">English</a>
+          <a href="/zh/" hreflang="zh-Hant" lang="zh-Hant" class="is-current" aria-current="true">繁體中文</a>
+          <a href="/fr/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/" hreflang="es" lang="es">Español</a>
+          <a href="/th/" hreflang="th" lang="th">ไทย</a>
+        </nav>
+        <div class="site-footer__bottom">
+          <span>© 2024-2026 Prokonjo. All rights reserved.</span>
+          <div class="site-footer__social">
+            <a href="https://github.com/prokonjo-team" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+              <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      // Mobile menu toggle
+      (function() {
+        var btn = document.querySelector('.menu-btn');
+        var menu = document.getElementById('mobile-menu');
+        if (!btn || !menu) return;
+        btn.addEventListener('click', function() {
+          var open = menu.dataset.open === 'true';
+          menu.dataset.open = open ? 'false' : 'true';
+          btn.setAttribute('aria-expanded', String(!open));
+        });
+        // Close on link tap
+        menu.querySelectorAll('a').forEach(function(a) {
+          a.addEventListener('click', function() {
+            menu.dataset.open = 'false';
+            btn.setAttribute('aria-expanded', 'false');
+          });
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/zh/privacy-policy/index.html
+++ b/zh/privacy-policy/index.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>隱私權政策｜Explores</title>
+    <meta name="description" content="Explores 的隱私權政策。關於位置資訊的處理方式與資料保留期間。" />
+    <meta name="theme-color" content="#FACD00" />
+    <meta name="robots" content="noindex" />
+    <link rel="canonical" href="https://prokonjo.com/zh/privacy-policy/" />
+    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/privacy-policy/" />
+    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/privacy-policy/" />
+    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/privacy-policy/" />
+    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/privacy-policy/" />
+    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/privacy-policy/" />
+    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/privacy-policy/" />
+    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/privacy-policy/" />
+    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/privacy-policy/" />
+    <link rel="icon" type="image/png" href="/assets/favicon.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/css/styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-P3YYZEG46Z');
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container site-header__inner">
+        <a class="site-header__brand" href="/zh/" aria-label="Explores 首頁">
+          <span class="site-header__brand-mark" aria-hidden="true">🧭</span>
+          <span>Explores</span>
+        </a>
+        <nav class="site-nav" aria-label="主選單">
+          <a href="/zh/#about">特色</a>
+          <a href="/zh/#how">玩法</a>
+          <a href="/zh/#awards">實績</a>
+          <a href="/zh/#faq">常見問題</a>
+          <a href="/zh/#contact">聯絡我們</a>
+        </nav>
+        <a class="btn site-header__cta" href="/zh/#download" aria-label="下載">
+          <svg class="site-header__cta-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>
+          <span class="site-header__cta-label">下載</span>
+        </a>
+        <button class="menu-btn" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="開啟選單">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+        </button>
+      </div>
+      <div id="mobile-menu" data-open="false">
+        <a href="/zh/#about">特色</a>
+        <a href="/zh/#how">玩法</a>
+        <a href="/zh/#awards">實績</a>
+        <a href="/zh/#faq">常見問題</a>
+        <a href="/zh/#contact">聯絡我們</a>
+        <a href="/zh/privacy-policy/">隱私權政策</a>
+        <div class="mobile-menu__lang" aria-label="語言 / Language">
+          <a href="/privacy-policy/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/privacy-policy/" hreflang="en" lang="en">English</a>
+          <a href="/zh/privacy-policy/" hreflang="zh-Hant" lang="zh-Hant" class="is-current" aria-current="true">繁體中文</a>
+          <a href="/fr/privacy-policy/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/privacy-policy/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/privacy-policy/" hreflang="es" lang="es">Español</a>
+          <a href="/th/privacy-policy/" hreflang="th" lang="th">ไทย</a>
+        </div>
+      </div>
+    </header>
+
+    <section class="page-header">
+      <div class="container">
+        <h1>隱私權政策</h1>
+        <p class="page-header__lead">關於 Explores 所處理的資訊及其使用目的。</p>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <article class="prose">
+          <p>本隱私權政策適用於 Taiki Akamatsu（以下稱「服務提供者」）免費提供的行動應用程式「Explores」（以下稱「本應用程式」）。本服務以「現狀」之利用為前提提供。</p>
+
+          <h2>收集的資訊與利用目的</h2>
+          <p>本應用程式於下載及使用時，可能收集以下資訊。</p>
+          <ul>
+            <li>裝置的 IP 位址</li>
+            <li>於本應用程式內所瀏覽的頁面、瀏覽日期時間及停留時間</li>
+            <li>本應用程式的使用時間</li>
+            <li>所使用之行動裝置的作業系統</li>
+          </ul>
+
+          <p>本應用程式會收集裝置的位置資訊。位置資訊用於判定大致的地理位置，並運用於以下用途。</p>
+          <ul>
+            <li><strong>位置資訊服務</strong>：提供個人化內容、相關性較高的推薦，以及基於位置資訊的功能</li>
+            <li><strong>分析與改善</strong>：以彙整、匿名化後的位置資訊為基礎，分析使用者行為並改善本應用程式整體的效能</li>
+            <li><strong>第三方服務</strong>：可能將匿名化後的位置資訊傳送至協助改善本應用程式或最佳化提供內容的外部服務</li>
+          </ul>
+
+          <p>服務提供者可能為與您聯繫之目的（重要通知、必要的告知、行銷資訊等）而利用所取得的資訊。此外，為提供更佳的體驗，可能會請您提供能夠識別特定個人的資訊，該等資訊將依本政策所載內容加以利用及保管。</p>
+
+          <h2>向第三方提供資訊</h2>
+          <p>僅會定期向外部服務傳送彙整、匿名化後的資料。服務提供者可能依本政策所載方式與第三方共享資訊。</p>
+
+          <p>本應用程式使用具有其自身隱私權政策的第三方服務。所使用之第三方服務的隱私權政策請參閱以下內容。</p>
+          <ul>
+            <li><a href="https://www.google.com/policies/privacy/" target="_blank" rel="noopener noreferrer">Google Play Services</a></li>
+          </ul>
+
+          <p>服務提供者於符合下列任一情形時，可能揭露使用者提供之資訊及自動收集之資訊。</p>
+          <ul>
+            <li>因應傳票或與其相當之法律程序等，依法令要求而須提供時</li>
+            <li>經本於誠信判斷，認為有保護服務提供者之權利、確保使用者或第三方之安全、調查不法行為、因應政府要求之必要時</li>
+            <li>受託代表服務提供者執行業務之可信賴服務供應商，已同意不獨立利用相關資訊並遵守本政策時</li>
+          </ul>
+
+          <h2>關於選擇退出（Opt-out）</h2>
+          <p>您可透過解除安裝本應用程式，全面停止資訊的收集。請使用您所使用裝置或商店的標準解除安裝程序。</p>
+
+          <h2>資料保留期間</h2>
+          <p>服務提供者將於您使用本應用程式期間及經判斷為合理之期間內，保留使用者提供之資料。若您希望刪除透過本應用程式所提供之資料，請來信至 <a href="mailto:akmatsutaiki@gmail.com">akmatsutaiki@gmail.com</a>。我們將於合理期間內予以處理。</p>
+
+          <h2>關於兒童的使用</h2>
+          <p>服務提供者不會透過本應用程式有意地向未滿 13 歲的兒童取得資料或進行行銷。</p>
+          <p>本應用程式並非以未滿 13 歲者為對象。萬一發現曾接收未滿 13 歲兒童所提供之個人資訊，將立即自伺服器刪除。若家長或監護人發現孩童曾提供個人資訊，請來信至 <a href="mailto:akmatsutaiki@gmail.com">akmatsutaiki@gmail.com</a>。</p>
+
+          <h2>安全性</h2>
+          <p>服務提供者致力於維護您資訊的機密性。為保護所處理及保管之資料，已採取實體、電子及程序上的安全措施。</p>
+
+          <h2>本政策的變更</h2>
+          <p>本隱私權政策可能視需要隨時更新。服務提供者將透過更新本頁面以告知變更內容。持續使用即視為您對所有變更之同意，故請定期確認。</p>
+
+          <p>本隱私權政策的生效日：<strong>2024-05-06</strong></p>
+
+          <h2>關於同意</h2>
+          <p>使用本應用程式即視為您同意依本隱私權政策處理您的資訊。</p>
+
+          <h2>聯絡我們</h2>
+          <p>若您對於使用本應用程式時的隱私，或對本政策有任何疑問，請來信至 <a href="mailto:akmatsutaiki@gmail.com">akmatsutaiki@gmail.com</a> 與我們聯繫。</p>
+
+          <hr />
+          <p style="font-size: 0.86rem; color: var(--c-text-muted);">本政策的製作使用了 <a href="https://app-privacy-policy-generator.nisrulz.com/" target="_blank" rel="noopener noreferrer">App Privacy Policy Generator</a>。</p>
+        </article>
+      </div>
+    </section>
+
+    <footer class="site-footer">
+      <div class="container">
+        <div class="site-footer__grid">
+          <div>
+            <div class="site-footer__brand">Explores</div>
+            <p class="site-footer__brand-line">將散步化為冒險的街頭漫遊遊戲。<br />by Prokonjo</p>
+          </div>
+          <div class="site-footer__col">
+            <h4>網站</h4>
+            <ul>
+              <li><a href="/zh/#about">特色</a></li>
+              <li><a href="/zh/#how">玩法</a></li>
+              <li><a href="/zh/#awards">實績</a></li>
+              <li><a href="/zh/#faq">常見問題</a></li>
+            </ul>
+          </div>
+          <div class="site-footer__col">
+            <h4>營運資訊</h4>
+            <ul>
+              <li><a href="/zh/privacy-policy/">隱私權政策</a></li>
+              <li><a href="/zh/#contact">聯絡我們</a></li>
+              <li><a href="/zh/tester-android/">Android 測試者</a></li>
+            </ul>
+          </div>
+        </div>
+        <nav class="lang-switch" aria-label="語言 / Language">
+          <span class="lang-switch__label">語言</span>
+          <a href="/privacy-policy/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/privacy-policy/" hreflang="en" lang="en">English</a>
+          <a href="/zh/privacy-policy/" hreflang="zh-Hant" lang="zh-Hant" class="is-current" aria-current="true">繁體中文</a>
+          <a href="/fr/privacy-policy/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/privacy-policy/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/privacy-policy/" hreflang="es" lang="es">Español</a>
+          <a href="/th/privacy-policy/" hreflang="th" lang="th">ไทย</a>
+        </nav>
+        <div class="site-footer__bottom">
+          <span>© 2024-2026 Prokonjo. All rights reserved.</span>
+          <div class="site-footer__social">
+            <a href="https://github.com/prokonjo-team" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+              <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      (function() {
+        var btn = document.querySelector('.menu-btn');
+        var menu = document.getElementById('mobile-menu');
+        if (!btn || !menu) return;
+        btn.addEventListener('click', function() {
+          var open = menu.dataset.open === 'true';
+          menu.dataset.open = open ? 'false' : 'true';
+          btn.setAttribute('aria-expanded', String(!open));
+        });
+        menu.querySelectorAll('a').forEach(function(a) {
+          a.addEventListener('click', function() {
+            menu.dataset.open = 'false';
+            btn.setAttribute('aria-expanded', 'false');
+          });
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/zh/tester-android/index.html
+++ b/zh/tester-android/index.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>Android 測試員招募中｜Explores</title>
+    <meta name="description" content="Explores 的 Android 測試員招募頁面。註冊 Google Groups → 安裝應用程式 → 啟動，共 3 個步驟。" />
+    <meta name="theme-color" content="#FACD00" />
+    <meta name="robots" content="noindex" />
+    <link rel="canonical" href="https://prokonjo.com/zh/tester-android/" />
+    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/tester-android/" />
+    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/tester-android/" />
+    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/tester-android/" />
+    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/tester-android/" />
+    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/tester-android/" />
+    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/tester-android/" />
+    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/tester-android/" />
+    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/tester-android/" />
+    <link rel="icon" type="image/png" href="/assets/favicon.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/css/styles.css" />
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-P3YYZEG46Z');
+    </script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container site-header__inner">
+        <a class="site-header__brand" href="/zh/" aria-label="Explores 首頁">
+          <span class="site-header__brand-mark" aria-hidden="true">🧭</span>
+          <span>Explores</span>
+        </a>
+        <nav class="site-nav" aria-label="主選單">
+          <a href="/zh/#about">特色</a>
+          <a href="/zh/#how">玩法</a>
+          <a href="/zh/#awards">成績</a>
+          <a href="/zh/#faq">FAQ</a>
+          <a href="/zh/#contact">聯絡我們</a>
+        </nav>
+        <a class="btn site-header__cta" href="/zh/#download" aria-label="下載">
+          <svg class="site-header__cta-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v12m0 0l-4-4m4 4l4-4M5 21h14"/></svg>
+          <span class="site-header__cta-label">下載</span>
+        </a>
+        <button class="menu-btn" type="button" aria-controls="mobile-menu" aria-expanded="false" aria-label="開啟選單">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+        </button>
+      </div>
+      <div id="mobile-menu" data-open="false">
+        <a href="/zh/#about">特色</a>
+        <a href="/zh/#how">玩法</a>
+        <a href="/zh/#awards">成績</a>
+        <a href="/zh/#faq">FAQ</a>
+        <a href="/zh/#contact">聯絡我們</a>
+        <a href="/zh/privacy-policy/">隱私權政策</a>
+        <div class="mobile-menu__lang" aria-label="語言 / Language">
+          <a href="/tester-android/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/tester-android/" hreflang="en" lang="en">English</a>
+          <a href="/zh/tester-android/" hreflang="zh-Hant" lang="zh-Hant" class="is-current" aria-current="true">繁體中文</a>
+          <a href="/fr/tester-android/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/tester-android/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/tester-android/" hreflang="es" lang="es">Español</a>
+          <a href="/th/tester-android/" hreflang="th" lang="th">ไทย</a>
+        </div>
+      </div>
+    </header>
+
+    <section class="page-header">
+      <div class="container">
+        <h1>Android 測試員招募中</h1>
+        <p class="page-header__lead">為了在 Google Play 正式上架，我們正在招募願意在 Android 上搶先體驗 Explores 的玩家。只要 3 個步驟即可完成參加！</p>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container container--narrow">
+        <div class="callout" style="margin-bottom: 2.5rem;">
+          <span class="callout__icon" aria-hidden="true">💡</span>
+          <div class="callout__body">
+            <strong>參加測試員時需要協助的事項</strong>
+            <p>共 3 項：安裝 Android 應用程式（必填）／啟動（必填）／填寫問卷（選填）。</p>
+          </div>
+        </div>
+
+        <div class="tester-step">
+          <div class="tester-step__num">1</div>
+          <div class="tester-step__body">
+            <h3>註冊 Google Groups</h3>
+            <p>請透過下方連結加入 Google Groups。若未加入測試員專用的 Google Groups，應用程式將無法在 Google Play 上顯示。</p>
+            <a class="btn" href="https://groups.google.com/search?q=explores_tester&inOrg=false" target="_blank" rel="noopener noreferrer">註冊 Google Groups</a>
+            <div class="tester-step__images">
+              <img src="/tester-android/imgs/1.png" alt="Google Groups 註冊步驟 1" loading="lazy" />
+              <img src="/tester-android/imgs/2.png" alt="Google Groups 註冊步驟 2" loading="lazy" />
+            </div>
+          </div>
+        </div>
+
+        <div class="tester-step">
+          <div class="tester-step__num">2</div>
+          <div class="tester-step__body">
+            <h3>安裝應用程式</h3>
+            <p>當 Google Groups 的註冊生效後，請透過下方連結在 Google Play 上安裝應用程式。</p>
+            <a class="btn" href="https://play.google.com/store/apps/details?id=com.prokonjo.explores" target="_blank" rel="noopener noreferrer">在 Google Play 上安裝</a>
+            <p style="margin-top: 1rem; font-size: 0.92rem;">若顯示「在這個伺服器上找不到您要求的網址。」，可能是 Google Groups 的註冊尚未生效。請稍候片刻後再試一次。</p>
+          </div>
+        </div>
+
+        <div class="tester-step">
+          <div class="tester-step__num">3</div>
+          <div class="tester-step__body">
+            <h3>啟動應用程式</h3>
+            <p>安裝完成後，啟動一次應用程式即可完成測試員登記。</p>
+            <div class="callout">
+              <span class="callout__icon" aria-hidden="true">⚠️</span>
+              <div class="callout__body">
+                <strong>溫馨提醒</strong>
+                <p>安裝之後，請勿刪除應用程式。一旦解除安裝，您就會被移出測試員名單。</p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="tester-step">
+          <div class="tester-step__num">+</div>
+          <div class="tester-step__body">
+            <h3>（選填）歡迎協助填寫問卷</h3>
+            <p>若能收到您對使用體驗的回饋，將有助於我們改善應用程式。</p>
+            <a class="btn btn--secondary" href="https://docs.google.com/forms/d/1sWQDp1t_8PnzxENLO9BHw-IYn2yrNgumjZMQWQWam8I" target="_blank" rel="noopener noreferrer">填寫問卷</a>
+          </div>
+        </div>
+
+        <div style="text-align: center; margin-top: 3rem;">
+          <a class="btn btn--ghost" href="/zh/">返回首頁</a>
+        </div>
+      </div>
+    </section>
+
+    <footer class="site-footer">
+      <div class="container">
+        <div class="site-footer__grid">
+          <div>
+            <div class="site-footer__brand">Explores</div>
+            <p class="site-footer__brand-line">把散步變成冒險的城市漫步遊戲。<br />by Prokonjo (prokonjo)</p>
+          </div>
+          <div class="site-footer__col">
+            <h4>網站</h4>
+            <ul>
+              <li><a href="/zh/#about">特色</a></li>
+              <li><a href="/zh/#how">玩法</a></li>
+              <li><a href="/zh/#awards">成績</a></li>
+              <li><a href="/zh/#faq">FAQ</a></li>
+            </ul>
+          </div>
+          <div class="site-footer__col">
+            <h4>營運資訊</h4>
+            <ul>
+              <li><a href="/zh/privacy-policy/">隱私權政策</a></li>
+              <li><a href="/zh/#contact">聯絡我們</a></li>
+              <li><a href="/zh/tester-android/">Android 測試員</a></li>
+            </ul>
+          </div>
+        </div>
+        <nav class="lang-switch" aria-label="語言 / Language">
+          <span class="lang-switch__label">語言</span>
+          <a href="/tester-android/" hreflang="ja" lang="ja">日本語</a>
+          <a href="/en/tester-android/" hreflang="en" lang="en">English</a>
+          <a href="/zh/tester-android/" hreflang="zh-Hant" lang="zh-Hant" class="is-current" aria-current="true">繁體中文</a>
+          <a href="/fr/tester-android/" hreflang="fr" lang="fr">Français</a>
+          <a href="/it/tester-android/" hreflang="it" lang="it">Italiano</a>
+          <a href="/es/tester-android/" hreflang="es" lang="es">Español</a>
+          <a href="/th/tester-android/" hreflang="th" lang="th">ไทย</a>
+        </nav>
+        <div class="site-footer__bottom">
+          <span>© 2024-2026 Prokonjo (prokonjo). All rights reserved.</span>
+          <div class="site-footer__social">
+            <a href="https://github.com/prokonjo-team" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+              <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 .5A11.5 11.5 0 00.5 12a11.5 11.5 0 007.86 10.92c.58.1.79-.25.79-.56v-2c-3.2.7-3.88-1.37-3.88-1.37-.52-1.32-1.27-1.67-1.27-1.67-1.04-.7.08-.69.08-.69 1.15.08 1.76 1.18 1.76 1.18 1.02 1.74 2.68 1.24 3.34.95.1-.74.4-1.24.73-1.53-2.55-.29-5.24-1.27-5.24-5.66 0-1.25.45-2.27 1.18-3.07-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.17a10.93 10.93 0 015.74 0c2.19-1.48 3.15-1.17 3.15-1.17.62 1.58.23 2.75.11 3.04.74.8 1.18 1.82 1.18 3.07 0 4.4-2.69 5.36-5.25 5.65.41.36.78 1.06.78 2.14v3.17c0 .31.21.67.79.55A11.5 11.5 0 0023.5 12 11.5 11.5 0 0012 .5z"/></svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      (function() {
+        var btn = document.querySelector('.menu-btn');
+        var menu = document.getElementById('mobile-menu');
+        if (!btn || !menu) return;
+        btn.addEventListener('click', function() {
+          var open = menu.dataset.open === 'true';
+          menu.dataset.open = open ? 'false' : 'true';
+          btn.setAttribute('aria-expanded', String(!open));
+        });
+        menu.querySelectorAll('a').forEach(function(a) {
+          a.addEventListener('click', function() {
+            menu.dataset.open = 'false';
+            btn.setAttribute('aria-expanded', 'false');
+          });
+        });
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## 概要
- スマホ表示でヘッダーの「ダウンロード」ボタンが折り返して崩れる不具合を修正
- LP全体（index / tester-android / privacy-policy）を6言語（en / zh / fr / it / es / th）に多言語化

## ボタン修正
- **767px以下**：ダウンロードCTAをアイコンのみのコンパクトなピルに（折り返しなし）
- **768px以上**：従来のテキストボタン（変更なし）
- ロゴの折り返しも防止。アイコン化により長い訳語（FR "Télécharger" 等）でもヘッダーが崩れない

## 多言語対応
- `/en/ /zh/ /fr/ /it/ /es/ /th/` に各ページを配置（`/` は日本語のまま）
- `hreflang` 相互リンク + `x-default`(ja)、フッター&モバイルドロワーに言語スイッチャー
- ブランドは「Explores」、中国語はストア資料に合わせ **繁體中文 (zh-Hant / 台湾)**
- App Storeバッジをロケール別に差し替え、内部リンクは言語プレフィックス付与、`/css`・`/assets` は絶対パスで共有
- tester / privacy は `noindex` 維持

## 検証
- 全18ページを自動チェック（**0 FAIL / 0 WARN**）：タグ構造一致・`<html lang>`・canonical・hreflang(8)・言語スイッチャーの is-current・かな残留0

## 注意（公開前に確認推奨）
- 翻訳本文はAIドラフト。特に**プライバシーポリシー（法務）**は公開前にネイティブ/法務確認推奨
- 開発チームのメンバー名は英語ページでローマ字化（公式表記があれば要差し替え）
- 言語別プラポリURLは `app-metadata.md` に記載済

Related: EXP-018

🤖 Generated with [Claude Code](https://claude.com/claude-code)