### PR TITLE
fix(lp): Android テスター導線を「準備中」表示に（全7言語・暫定対応）

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -135,7 +135,7 @@
             <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="Download on the App Store">
               <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
             </a>
-            <a class="btn btn--secondary" href="/en/tester-android">Android (testers wanted)</a>
+            <a class="btn btn--secondary" href="/en/tester-android">Android (coming soon)</a>
           </div>
           <p class="hero__note">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>
@@ -345,7 +345,7 @@
           </details>
           <details>
             <summary>Is there an Android version?</summary>
-            <p>We're currently looking for testers ahead of our Google Play release. You can sign up to be a tester on <a href="/en/tester-android">this page</a>.</p>
+            <p>We're currently rebuilding our Android release setup, so tester recruitment is paused for now. We'll post an update on <a href="/en/tester-android">this page</a> as soon as it's ready.</p>
           </details>
         </div>
       </div>
@@ -360,7 +360,7 @@
           <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="Download on the App Store">
             <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
           </a>
-          <a class="btn" href="/en/tester-android" style="background:#fff;">Android (testers wanted)</a>
+          <a class="btn" href="/en/tester-android" style="background:#fff;">Android (coming soon)</a>
         </div>
       </div>
     </section>

--- a/en/tester-android/index.html
+++ b/en/tester-android/index.html
@@ -72,13 +72,21 @@
 
     <section class="page-header">
       <div class="container">
-        <h1>Now Recruiting Android Testers</h1>
+        <h1>Android Testers (Coming Soon)</h1>
         <p class="page-header__lead">Ahead of our Google Play launch, we're looking for people to play Explores early on Android. Join in just 3 steps!</p>
       </div>
     </section>
 
     <section class="section">
       <div class="container container--narrow">
+        <div class="callout" style="margin-bottom: 2.5rem;">
+          <span class="callout__icon" aria-hidden="true">🚧</span>
+          <div class="callout__body">
+            <strong>The Android version is being prepared</strong>
+            <p>We're rebuilding our test environment, so new tester sign-ups are paused for now. We'll post an update here as soon as it's ready. Want early access? <a href="/en/#contact">Get in touch</a> and we'll notify you first.</p>
+          </div>
+        </div>
+
         <div class="callout" style="margin-bottom: 2.5rem;">
           <span class="callout__icon" aria-hidden="true">💡</span>
           <div class="callout__body">
@@ -92,7 +100,7 @@
           <div class="tester-step__body">
             <h3>Register on Google Groups</h3>
             <p>Join the Google Group via the link below. Unless you're in the tester Google Group, the app won't appear for you on Google Play.</p>
-            <a class="btn" href="https://groups.google.com/search?q=explores_tester&inOrg=false" target="_blank" rel="noopener noreferrer">Register on Google Groups</a>
+            <span class="btn" aria-disabled="true" style="opacity:.5; pointer-events:none;">Register on Google Groups (coming soon)</span>
             <div class="tester-step__images">
               <img src="/tester-android/imgs/1.png" alt="Google Groups registration step 1" loading="lazy" />
               <img src="/tester-android/imgs/2.png" alt="Google Groups registration step 2" loading="lazy" />
@@ -105,7 +113,7 @@
           <div class="tester-step__body">
             <h3>Install the app</h3>
             <p>Once your Google Groups registration has gone through, install the app from Google Play using the link below.</p>
-            <a class="btn" href="https://play.google.com/store/apps/details?id=com.prokonjo.explores" target="_blank" rel="noopener noreferrer">Install on Google Play</a>
+            <span class="btn" aria-disabled="true" style="opacity:.5; pointer-events:none;">Install on Google Play (coming soon)</span>
             <p style="margin-top: 1rem; font-size: 0.92rem;">If you see "The requested URL was not found on this server," your Google Groups registration may not have taken effect yet. Please wait a little while and try again.</p>
           </div>
         </div>

--- a/es/index.html
+++ b/es/index.html
@@ -135,7 +135,7 @@
             <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="Descargar en el App Store">
               <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/es-es?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
             </a>
-            <a class="btn btn--secondary" href="/es/tester-android">Android (buscamos probadores)</a>
+            <a class="btn btn--secondary" href="/es/tester-android">Android (próximamente)</a>
           </div>
           <p class="hero__note">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>
@@ -345,7 +345,7 @@
           </details>
           <details>
             <summary>¿Hay versión para Android?</summary>
-            <p>Ahora mismo buscamos probadores de cara a la publicación en Google Play. Puedes registrarte como probador desde <a href="/es/tester-android">esta página</a>.</p>
+            <p>Ahora mismo estamos reconfigurando la publicación en Android, así que la búsqueda de probadores está pausada. Publicaremos una actualización en <a href="/es/tester-android">esta página</a> en cuanto esté lista.</p>
           </details>
         </div>
       </div>
@@ -360,7 +360,7 @@
           <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="Descargar en el App Store">
             <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/es-es?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
           </a>
-          <a class="btn" href="/es/tester-android" style="background:#fff;">Android (buscamos probadores)</a>
+          <a class="btn" href="/es/tester-android" style="background:#fff;">Android (próximamente)</a>
         </div>
       </div>
     </section>

--- a/es/tester-android/index.html
+++ b/es/tester-android/index.html
@@ -72,13 +72,21 @@
 
     <section class="page-header">
       <div class="container">
-        <h1>Buscamos testers de Android</h1>
+        <h1>Testers de Android (próximamente)</h1>
         <p class="page-header__lead">De cara al lanzamiento en Google Play, buscamos personas que quieran probar Explores en Android antes que nadie. ¡Apúntate en solo 3 pasos!</p>
       </div>
     </section>
 
     <section class="section">
       <div class="container container--narrow">
+        <div class="callout" style="margin-bottom: 2.5rem;">
+          <span class="callout__icon" aria-hidden="true">🚧</span>
+          <div class="callout__body">
+            <strong>La versión de Android está en preparación</strong>
+            <p>Estamos reconfigurando nuestro entorno de pruebas, así que las nuevas inscripciones de testers están pausadas por ahora. Publicaremos una actualización aquí en cuanto esté lista. ¿Quieres acceso anticipado? <a href="/es/#contact">Escríbenos</a> y te avisaremos primero.</p>
+          </div>
+        </div>
+
         <div class="callout" style="margin-bottom: 2.5rem;">
           <span class="callout__icon" aria-hidden="true">💡</span>
           <div class="callout__body">
@@ -92,7 +100,7 @@
           <div class="tester-step__body">
             <h3>Regístrate en Google Groups</h3>
             <p>Únete a Google Groups desde el enlace de abajo. Si no estás en el Google Groups de testers, la app no aparecerá en Google Play.</p>
-            <a class="btn" href="https://groups.google.com/search?q=explores_tester&inOrg=false" target="_blank" rel="noopener noreferrer">Registrarse en Google Groups</a>
+            <span class="btn" aria-disabled="true" style="opacity:.5; pointer-events:none;">Registrarse en Google Groups (próximamente)</span>
             <div class="tester-step__images">
               <img src="/tester-android/imgs/1.png" alt="Pasos para registrarse en Google Groups 1" loading="lazy" />
               <img src="/tester-android/imgs/2.png" alt="Pasos para registrarse en Google Groups 2" loading="lazy" />
@@ -105,7 +113,7 @@
           <div class="tester-step__body">
             <h3>Instala la app</h3>
             <p>Una vez que tu registro en Google Groups se haya aplicado, instala la app desde Google Play usando el enlace de abajo.</p>
-            <a class="btn" href="https://play.google.com/store/apps/details?id=com.prokonjo.explores" target="_blank" rel="noopener noreferrer">Instalar desde Google Play</a>
+            <span class="btn" aria-disabled="true" style="opacity:.5; pointer-events:none;">Instalar desde Google Play (próximamente)</span>
             <p style="margin-top: 1rem; font-size: 0.92rem;">Si aparece el mensaje «No se encontró la URL solicitada en este servidor.», es posible que tu registro en Google Groups aún no se haya aplicado. Espera un momento y vuelve a intentarlo.</p>
           </div>
         </div>

--- a/fr/index.html
+++ b/fr/index.html
@@ -135,7 +135,7 @@
             <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="Télécharger dans l'App Store">
               <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/fr-fr?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
             </a>
-            <a class="btn btn--secondary" href="/fr/tester-android">Android (recherche de testeurs)</a>
+            <a class="btn btn--secondary" href="/fr/tester-android">Android (bientôt disponible)</a>
           </div>
           <p class="hero__note">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>
@@ -345,7 +345,7 @@
           </details>
           <details>
             <summary>Existe-t-il une version Android ?</summary>
-            <p>Nous recherchons actuellement des testeurs en vue de la publication sur Google Play. Vous pouvez vous inscrire comme testeur depuis <a href="/fr/tester-android">cette page</a>.</p>
+            <p>Nous reconfigurons actuellement notre publication Android ; le recrutement de testeurs est donc suspendu pour le moment. Nous publierons une mise à jour sur <a href="/fr/tester-android">cette page</a> dès que possible.</p>
           </details>
         </div>
       </div>
@@ -360,7 +360,7 @@
           <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="Télécharger dans l'App Store">
             <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/fr-fr?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
           </a>
-          <a class="btn" href="/fr/tester-android" style="background:#fff;">Android (recherche de testeurs)</a>
+          <a class="btn" href="/fr/tester-android" style="background:#fff;">Android (bientôt disponible)</a>
         </div>
       </div>
     </section>

--- a/fr/tester-android/index.html
+++ b/fr/tester-android/index.html
@@ -72,13 +72,21 @@
 
     <section class="page-header">
       <div class="container">
-        <h1>Recherche de testeurs Android</h1>
+        <h1>Testeurs Android (bientôt)</h1>
         <p class="page-header__lead">En vue de la sortie sur Google Play, nous recherchons des personnes prêtes à jouer en avant-première à Explores sur Android. Trois étapes suffisent pour participer !</p>
       </div>
     </section>
 
     <section class="section">
       <div class="container container--narrow">
+        <div class="callout" style="margin-bottom: 2.5rem;">
+          <span class="callout__icon" aria-hidden="true">🚧</span>
+          <div class="callout__body">
+            <strong>La version Android est en préparation</strong>
+            <p>Nous reconfigurons notre environnement de test ; les nouvelles inscriptions de testeurs sont donc suspendues pour le moment. Nous publierons une mise à jour ici dès que possible. Envie d'un accès anticipé ? <a href="/fr/#contact">Contactez-nous</a> et nous vous préviendrons en priorité.</p>
+          </div>
+        </div>
+
         <div class="callout" style="margin-bottom: 2.5rem;">
           <span class="callout__icon" aria-hidden="true">💡</span>
           <div class="callout__body">
@@ -92,7 +100,7 @@
           <div class="tester-step__body">
             <h3>S'inscrire au Google Groups</h3>
             <p>Rejoignez le Google Groups via le lien ci-dessous. Sans appartenir au Google Groups dédié aux testeurs, l'application ne s'affichera pas sur Google Play.</p>
-            <a class="btn" href="https://groups.google.com/search?q=explores_tester&inOrg=false" target="_blank" rel="noopener noreferrer">S'inscrire au Google Groups</a>
+            <span class="btn" aria-disabled="true" style="opacity:.5; pointer-events:none;">S'inscrire au Google Groups (bientôt)</span>
             <div class="tester-step__images">
               <img src="/tester-android/imgs/1.png" alt="Procédure d'inscription au Google Groups 1" loading="lazy" />
               <img src="/tester-android/imgs/2.png" alt="Procédure d'inscription au Google Groups 2" loading="lazy" />
@@ -105,7 +113,7 @@
           <div class="tester-step__body">
             <h3>Installer l'application</h3>
             <p>Une fois votre inscription au Google Groups prise en compte, installez l'application sur Google Play via le lien ci-dessous.</p>
-            <a class="btn" href="https://play.google.com/store/apps/details?id=com.prokonjo.explores" target="_blank" rel="noopener noreferrer">Installer sur Google Play</a>
+            <span class="btn" aria-disabled="true" style="opacity:.5; pointer-events:none;">Installer sur Google Play (bientôt)</span>
             <p style="margin-top: 1rem; font-size: 0.92rem;">Si le message « L'URL demandée est introuvable sur ce serveur. » s'affiche, il est possible que votre inscription au Google Groups ne soit pas encore prise en compte. Patientez un instant, puis réessayez.</p>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
             <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="App Store からダウンロード">
               <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/ja-jp?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
             </a>
-            <a class="btn btn--secondary" href="/tester-android">Android（テスター募集中）</a>
+            <a class="btn btn--secondary" href="/tester-android">Android（準備中）</a>
           </div>
           <p class="hero__note">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>
@@ -345,7 +345,7 @@
           </details>
           <details>
             <summary>Android 版はありますか？</summary>
-            <p>現在、Google Play 公開に向けてテスターさんを募集中です。<a href="/tester-android">こちらのページ</a>からテスター登録できます。</p>
+            <p>現在、Android版は配信の準備を整え直しているところで、テスター募集を一時停止しています。準備が整い次第、<a href="/tester-android">こちらのページ</a>でご案内します。</p>
           </details>
         </div>
       </div>
@@ -360,7 +360,7 @@
           <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="App Store からダウンロード">
             <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/ja-jp?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
           </a>
-          <a class="btn" href="/tester-android" style="background:#fff;">Android（テスター募集中）</a>
+          <a class="btn" href="/tester-android" style="background:#fff;">Android（準備中）</a>
         </div>
       </div>
     </section>

--- a/it/index.html
+++ b/it/index.html
@@ -135,7 +135,7 @@
             <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="Scarica sull'App Store">
               <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/it-it?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
             </a>
-            <a class="btn btn--secondary" href="/it/tester-android">Android (cerchiamo tester)</a>
+            <a class="btn btn--secondary" href="/it/tester-android">Android (in arrivo)</a>
           </div>
           <p class="hero__note">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>
@@ -345,7 +345,7 @@
           </details>
           <details>
             <summary>Esiste la versione Android?</summary>
-            <p>Al momento stiamo cercando tester in vista della pubblicazione su Google Play. Puoi registrarti come tester da <a href="/it/tester-android">questa pagina</a>.</p>
+            <p>Al momento stiamo riconfigurando la pubblicazione su Android, quindi il reclutamento dei tester è sospeso. Pubblicheremo un aggiornamento su <a href="/it/tester-android">questa pagina</a> appena sarà pronto.</p>
           </details>
         </div>
       </div>
@@ -360,7 +360,7 @@
           <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="Scarica sull'App Store">
             <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/it-it?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
           </a>
-          <a class="btn" href="/it/tester-android" style="background:#fff;">Android (cerchiamo tester)</a>
+          <a class="btn" href="/it/tester-android" style="background:#fff;">Android (in arrivo)</a>
         </div>
       </div>
     </section>

--- a/it/tester-android/index.html
+++ b/it/tester-android/index.html
@@ -72,13 +72,21 @@
 
     <section class="page-header">
       <div class="container">
-        <h1>Cerchiamo tester Android</h1>
+        <h1>Tester Android (in arrivo)</h1>
         <p class="page-header__lead">In vista della pubblicazione su Google Play, cerchiamo persone che vogliano provare Explores in anteprima su Android. Bastano 3 passaggi per partecipare!</p>
       </div>
     </section>
 
     <section class="section">
       <div class="container container--narrow">
+        <div class="callout" style="margin-bottom: 2.5rem;">
+          <span class="callout__icon" aria-hidden="true">🚧</span>
+          <div class="callout__body">
+            <strong>La versione Android è in preparazione</strong>
+            <p>Stiamo riconfigurando l'ambiente di test, quindi le nuove iscrizioni dei tester sono sospese per ora. Pubblicheremo un aggiornamento qui appena sarà pronta. Vuoi l'accesso anticipato? <a href="/it/#contact">Contattaci</a> e ti avviseremo per primo.</p>
+          </div>
+        </div>
+
         <div class="callout" style="margin-bottom: 2.5rem;">
           <span class="callout__icon" aria-hidden="true">💡</span>
           <div class="callout__body">
@@ -92,7 +100,7 @@
           <div class="tester-step__body">
             <h3>Iscriviti a Google Groups</h3>
             <p>Iscriviti a Google Groups tramite il link qui sotto. Se non fai parte del Google Groups dedicato ai tester, l'app non sarà visibile su Google Play.</p>
-            <a class="btn" href="https://groups.google.com/search?q=explores_tester&inOrg=false" target="_blank" rel="noopener noreferrer">Iscriviti a Google Groups</a>
+            <span class="btn" aria-disabled="true" style="opacity:.5; pointer-events:none;">Iscriviti a Google Groups (in arrivo)</span>
             <div class="tester-step__images">
               <img src="/tester-android/imgs/1.png" alt="Iscrizione a Google Groups, passaggio 1" loading="lazy" />
               <img src="/tester-android/imgs/2.png" alt="Iscrizione a Google Groups, passaggio 2" loading="lazy" />
@@ -105,7 +113,7 @@
           <div class="tester-step__body">
             <h3>Installa l'app</h3>
             <p>Una volta che l'iscrizione a Google Groups è stata registrata, installa l'app da Google Play tramite il link qui sotto.</p>
-            <a class="btn" href="https://play.google.com/store/apps/details?id=com.prokonjo.explores" target="_blank" rel="noopener noreferrer">Installa da Google Play</a>
+            <span class="btn" aria-disabled="true" style="opacity:.5; pointer-events:none;">Installa da Google Play (in arrivo)</span>
             <p style="margin-top: 1rem; font-size: 0.92rem;">Se compare il messaggio "L'URL richiesto non è stato trovato su questo server.", è possibile che l'iscrizione a Google Groups non sia ancora stata registrata. Attendi qualche minuto e riprova.</p>
           </div>
         </div>

--- a/tester-android/index.html
+++ b/tester-android/index.html
@@ -72,13 +72,21 @@
 
     <section class="page-header">
       <div class="container">
-        <h1>Android テスター募集中</h1>
+        <h1>Android テスター（準備中）</h1>
         <p class="page-header__lead">Google Play 公開に向けて、エクスプロラーズを Android で先行プレイしてくださる方を募集しています。3 ステップで参加完了！</p>
       </div>
     </section>
 
     <section class="section">
       <div class="container container--narrow">
+        <div class="callout" style="margin-bottom: 2.5rem;">
+          <span class="callout__icon" aria-hidden="true">🚧</span>
+          <div class="callout__body">
+            <strong>Android版は現在準備中です</strong>
+            <p>テスト環境を整え直しているため、新規のテスター参加を一時停止しています。準備が整い次第このページでご案内します。ひと足先に試したい方は<a href="/#contact">お問い合わせ</a>からご連絡ください（準備でき次第、最優先でご案内します）。</p>
+          </div>
+        </div>
+
         <div class="callout" style="margin-bottom: 2.5rem;">
           <span class="callout__icon" aria-hidden="true">💡</span>
           <div class="callout__body">
@@ -92,7 +100,7 @@
           <div class="tester-step__body">
             <h3>Google Groups に登録する</h3>
             <p>下記のリンクから Google Groups に参加してください。テスター用の Google Groups に入っていないと、Google Play でのアプリ表示ができません。</p>
-            <a class="btn" href="https://groups.google.com/search?q=explores_tester&inOrg=false" target="_blank" rel="noopener noreferrer">Google Groups に登録</a>
+            <span class="btn" aria-disabled="true" style="opacity:.5; pointer-events:none;">Google Groups に登録（準備中）</span>
             <div class="tester-step__images">
               <img src="/tester-android/imgs/1.png" alt="Google Groups 登録手順 1" loading="lazy" />
               <img src="/tester-android/imgs/2.png" alt="Google Groups 登録手順 2" loading="lazy" />
@@ -105,7 +113,7 @@
           <div class="tester-step__body">
             <h3>アプリをインストールする</h3>
             <p>Google Groups の登録が反映されたら、下記のリンクから Google Play でアプリをインストールしてください。</p>
-            <a class="btn" href="https://play.google.com/store/apps/details?id=com.prokonjo.explores" target="_blank" rel="noopener noreferrer">Google Play でインストール</a>
+            <span class="btn" aria-disabled="true" style="opacity:.5; pointer-events:none;">Google Play でインストール（準備中）</span>
             <p style="margin-top: 1rem; font-size: 0.92rem;">「リクエストされた URL は、このサーバー上に見つかりませんでした。」と表示される場合は、Google Groups の登録が反映されていない可能性があります。少し時間を置いてから再度お試しください。</p>
           </div>
         </div>

--- a/th/index.html
+++ b/th/index.html
@@ -135,7 +135,7 @@
             <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="ดาวน์โหลดบน App Store">
               <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/th-th?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
             </a>
-            <a class="btn btn--secondary" href="/th/tester-android">Android (กำลังรับสมัครผู้ทดสอบ)</a>
+            <a class="btn btn--secondary" href="/th/tester-android">Android (เร็ว ๆ นี้)</a>
           </div>
           <p class="hero__note">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>
@@ -345,7 +345,7 @@
           </details>
           <details>
             <summary>มีเวอร์ชัน Android ไหม?</summary>
-            <p>ขณะนี้กำลังรับสมัครผู้ทดสอบเพื่อเตรียมเผยแพร่บน Google Play คุณสามารถลงทะเบียนเป็นผู้ทดสอบได้จาก<a href="/th/tester-android">หน้านี้</a></p>
+            <p>ขณะนี้เรากำลังจัดเตรียมการเผยแพร่บน Android ใหม่ จึงหยุดรับสมัครผู้ทดสอบชั่วคราว เราจะแจ้งให้ทราบที่<a href="/th/tester-android">หน้านี้</a>เมื่อพร้อม</p>
           </details>
         </div>
       </div>
@@ -360,7 +360,7 @@
           <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="ดาวน์โหลดบน App Store">
             <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/th-th?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
           </a>
-          <a class="btn" href="/th/tester-android" style="background:#fff;">Android (กำลังรับสมัครผู้ทดสอบ)</a>
+          <a class="btn" href="/th/tester-android" style="background:#fff;">Android (เร็ว ๆ นี้)</a>
         </div>
       </div>
     </section>

--- a/th/tester-android/index.html
+++ b/th/tester-android/index.html
@@ -72,13 +72,21 @@
 
     <section class="page-header">
       <div class="container">
-        <h1>กำลังรับสมัครผู้ทดสอบ Android</h1>
+        <h1>ผู้ทดสอบ Android (เร็ว ๆ นี้)</h1>
         <p class="page-header__lead">เรากำลังมองหาผู้ที่จะมาเล่น Explores บน Android ก่อนใคร เพื่อเตรียมเปิดตัวบน Google Play สมัครเข้าร่วมได้เลยใน 3 ขั้นตอน!</p>
       </div>
     </section>
 
     <section class="section">
       <div class="container container--narrow">
+        <div class="callout" style="margin-bottom: 2.5rem;">
+          <span class="callout__icon" aria-hidden="true">🚧</span>
+          <div class="callout__body">
+            <strong>เวอร์ชัน Android กำลังอยู่ระหว่างการเตรียมการ</strong>
+            <p>เรากำลังจัดเตรียมระบบทดสอบใหม่ จึงขอหยุดรับผู้ทดสอบรายใหม่ชั่วคราว เราจะแจ้งให้ทราบที่หน้านี้เมื่อพร้อม หากต้องการทดลองก่อนใคร โปรด<a href="/th/#contact">ติดต่อเรา</a> แล้วเราจะแจ้งคุณเป็นคนแรก</p>
+          </div>
+        </div>
+
         <div class="callout" style="margin-bottom: 2.5rem;">
           <span class="callout__icon" aria-hidden="true">💡</span>
           <div class="callout__body">
@@ -92,7 +100,7 @@
           <div class="tester-step__body">
             <h3>ลงทะเบียน Google Groups</h3>
             <p>โปรดเข้าร่วม Google Groups จากลิงก์ด้านล่าง หากยังไม่ได้เข้า Google Groups สำหรับผู้ทดสอบ จะไม่สามารถแสดงแอปบน Google Play ได้</p>
-            <a class="btn" href="https://groups.google.com/search?q=explores_tester&inOrg=false" target="_blank" rel="noopener noreferrer">ลงทะเบียน Google Groups</a>
+            <span class="btn" aria-disabled="true" style="opacity:.5; pointer-events:none;">ลงทะเบียน Google Groups (เร็ว ๆ นี้)</span>
             <div class="tester-step__images">
               <img src="/tester-android/imgs/1.png" alt="ขั้นตอนการลงทะเบียน Google Groups 1" loading="lazy" />
               <img src="/tester-android/imgs/2.png" alt="ขั้นตอนการลงทะเบียน Google Groups 2" loading="lazy" />
@@ -105,7 +113,7 @@
           <div class="tester-step__body">
             <h3>ติดตั้งแอป</h3>
             <p>เมื่อการลงทะเบียน Google Groups มีผลแล้ว โปรดติดตั้งแอปบน Google Play จากลิงก์ด้านล่าง</p>
-            <a class="btn" href="https://play.google.com/store/apps/details?id=com.prokonjo.explores" target="_blank" rel="noopener noreferrer">ติดตั้งบน Google Play</a>
+            <span class="btn" aria-disabled="true" style="opacity:.5; pointer-events:none;">ติดตั้งบน Google Play (เร็ว ๆ นี้)</span>
             <p style="margin-top: 1rem; font-size: 0.92rem;">หากปรากฏข้อความว่า "ไม่พบ URL ที่ร้องขอบนเซิร์ฟเวอร์นี้" อาจเป็นเพราะการลงทะเบียน Google Groups ยังไม่มีผล โปรดรอสักครู่แล้วลองใหม่อีกครั้ง</p>
           </div>
         </div>

--- a/zh/index.html
+++ b/zh/index.html
@@ -135,7 +135,7 @@
             <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="從 App Store 下載">
               <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/zh-tw?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
             </a>
-            <a class="btn btn--secondary" href="/zh/tester-android">Android（招募測試者中）</a>
+            <a class="btn btn--secondary" href="/zh/tester-android">Android（準備中）</a>
           </div>
           <p class="hero__note">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>
@@ -345,7 +345,7 @@
           </details>
           <details>
             <summary>有 Android 版嗎？</summary>
-            <p>目前正為了在 Google Play 上架而招募測試者中。歡迎從<a href="/zh/tester-android">這個頁面</a>登錄成為測試者。</p>
+            <p>目前正在重新整理 Android 的發佈環境，暫停招募測試者。準備就緒後將於<a href="/zh/tester-android">這個頁面</a>公布。</p>
           </details>
         </div>
       </div>
@@ -360,7 +360,7 @@
           <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="從 App Store 下載">
             <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/zh-tw?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
           </a>
-          <a class="btn" href="/zh/tester-android" style="background:#fff;">Android（招募測試者中）</a>
+          <a class="btn" href="/zh/tester-android" style="background:#fff;">Android（準備中）</a>
         </div>
       </div>
     </section>

--- a/zh/tester-android/index.html
+++ b/zh/tester-android/index.html
@@ -72,13 +72,21 @@
 
     <section class="page-header">
       <div class="container">
-        <h1>Android 測試員招募中</h1>
+        <h1>Android 測試員（準備中）</h1>
         <p class="page-header__lead">為了在 Google Play 正式上架，我們正在招募願意在 Android 上搶先體驗 Explores 的玩家。只要 3 個步驟即可完成參加！</p>
       </div>
     </section>
 
     <section class="section">
       <div class="container container--narrow">
+        <div class="callout" style="margin-bottom: 2.5rem;">
+          <span class="callout__icon" aria-hidden="true">🚧</span>
+          <div class="callout__body">
+            <strong>Android 版本正在準備中</strong>
+            <p>我們正在重新整理測試環境，暫停新測試員的加入。準備就緒後將於本頁公布。想搶先體驗，歡迎透過<a href="/zh/#contact">聯絡我們</a>與我們聯繫，我們會優先通知您。</p>
+          </div>
+        </div>
+
         <div class="callout" style="margin-bottom: 2.5rem;">
           <span class="callout__icon" aria-hidden="true">💡</span>
           <div class="callout__body">
@@ -92,7 +100,7 @@
           <div class="tester-step__body">
             <h3>註冊 Google Groups</h3>
             <p>請透過下方連結加入 Google Groups。若未加入測試員專用的 Google Groups，應用程式將無法在 Google Play 上顯示。</p>
-            <a class="btn" href="https://groups.google.com/search?q=explores_tester&inOrg=false" target="_blank" rel="noopener noreferrer">註冊 Google Groups</a>
+            <span class="btn" aria-disabled="true" style="opacity:.5; pointer-events:none;">註冊 Google Groups（準備中）</span>
             <div class="tester-step__images">
               <img src="/tester-android/imgs/1.png" alt="Google Groups 註冊步驟 1" loading="lazy" />
               <img src="/tester-android/imgs/2.png" alt="Google Groups 註冊步驟 2" loading="lazy" />
@@ -105,7 +113,7 @@
           <div class="tester-step__body">
             <h3>安裝應用程式</h3>
             <p>當 Google Groups 的註冊生效後，請透過下方連結在 Google Play 上安裝應用程式。</p>
-            <a class="btn" href="https://play.google.com/store/apps/details?id=com.prokonjo.explores" target="_blank" rel="noopener noreferrer">在 Google Play 上安裝</a>
+            <span class="btn" aria-disabled="true" style="opacity:.5; pointer-events:none;">在 Google Play 上安裝（準備中）</span>
             <p style="margin-top: 1rem; font-size: 0.92rem;">若顯示「在這個伺服器上找不到您要求的網址。」，可能是 Google Groups 的註冊尚未生效。請稍候片刻後再試一次。</p>
           </div>
         </div>


### PR DESCRIPTION
## 背景
Google Play デベロッパーアカウントが**非アクティブ閉鎖**されたため、`/tester-android` のテスター導線（Google Groups 登録 → Google Play インストール）が**デッドエンド化**しています。実際に LP 経由で参加しようとした方が Google Groups の画面で詰まる事例が発生しました。

復帰には新アカウントでの再公開が必要で**数週間かかる**見込みのため、それまでの暫定対応として Android 導線を「準備中」表示に切り替えます。

## 変更内容（全7言語: ja / en / zh / fr / it / es / th）
- **tester-android**: 冒頭に 🚧「準備中・新規テスター参加を一時停止」callout を追加 / Google Groups・Google Play ボタンを無効化（`<span>` 化）/ H1 を「（準備中）」に
- **index**: Android CTA ラベル（ヒーロー＋下部CTAの2箇所）と FAQ「Android版はありますか？」を準備中表記に

## 復活方法
テスト再開時は本PRを **revert** すれば元の3ステップ導線に戻ります（新しい opt-in URL に差し替えて再開）。

## 注意
- 非日本語の文言は AI ドラフトです。公開前にネイティブ確認推奨。
- `#contact` アンカーへのリンクを各言語ホームに張っています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
