### PR TITLE
feat(lp): SEO技術クイックウィン — sitemap/robots/404 + クロール&CWV修正（全7言語）

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+    <title>ページが見つかりません (404)｜エクスプローラーズ</title>
+    <meta name="robots" content="noindex" />
+    <meta name="theme-color" content="#FACD00" />
+    <link rel="icon" type="image/png" href="/assets/favicon.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@700;800;900&family=Noto+Sans+JP:wght@400;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/css/styles.css" />
+    <style>
+      .nf { min-height: 100vh; display: flex; flex-direction: column; align-items: center; justify-content: center; text-align: center; padding: 2rem 1.25rem; gap: 1rem; }
+      .nf__mark { font-size: 3rem; }
+      .nf__code { font-family: var(--font-heading, sans-serif); font-weight: 900; font-size: clamp(3rem, 12vw, 6rem); line-height: 1; color: #FACD00; margin: 0; }
+      .nf__msg { max-width: 36rem; margin: 0 auto; }
+      .nf__langs { display: flex; flex-wrap: wrap; gap: .5rem 1rem; justify-content: center; margin-top: .5rem; }
+    </style>
+  </head>
+  <body>
+    <main class="nf">
+      <span class="nf__mark" aria-hidden="true">🧭</span>
+      <p class="nf__code">404</p>
+      <div class="nf__msg">
+        <h1>ページが見つかりませんでした</h1>
+        <p>お探しのページは移動または削除された可能性があります。<br />The page you’re looking for can’t be found.</p>
+      </div>
+      <a class="btn" href="/">トップへ戻る / Home</a>
+      <nav class="nf__langs" aria-label="言語 / Language">
+        <a href="/" hreflang="ja" lang="ja">日本語</a>
+        <a href="/en/" hreflang="en" lang="en">English</a>
+        <a href="/zh/" hreflang="zh-Hant" lang="zh-Hant">繁體中文</a>
+        <a href="/fr/" hreflang="fr" lang="fr">Français</a>
+        <a href="/it/" hreflang="it" lang="it">Italiano</a>
+        <a href="/es/" hreflang="es" lang="es">Español</a>
+        <a href="/th/" hreflang="th" lang="th">ไทย</a>
+      </nav>
+    </main>
+  </body>
+</html>

--- a/en/index.html
+++ b/en/index.html
@@ -39,11 +39,12 @@
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
+    <link rel="preload" as="image" href="/assets/img/game-desc.jpg" fetchpriority="high" />
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@700;800;900&family=Noto+Sans+JP:wght@400;600;700&display=swap" rel="stylesheet" />
 
     <link rel="stylesheet" href="/css/styles.css" />
 
@@ -132,10 +133,10 @@
             About 15 minutes a round. A walking game that's free, with no in-app purchases.
           </p>
           <div class="hero__cta">
-            <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="Download on the App Store">
+            <a class="app-badge" href="https://apps.apple.com/app/id6477759574" aria-label="Download on the App Store">
               <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
             </a>
-            <a class="btn btn--secondary" href="/en/tester-android">Android (coming soon)</a>
+            <a class="btn btn--secondary" href="/en/tester-android/">Android (coming soon)</a>
           </div>
           <p class="hero__note">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>
@@ -143,7 +144,7 @@
           </p>
         </div>
         <div class="hero__visual">
-          <img src="/assets/img/game-desc.jpg" alt="A look at Explores gameplay" width="1200" height="676" />
+          <img src="/assets/img/game-desc.jpg" alt="A look at Explores gameplay" width="1555" height="556" fetchpriority="high" />
         </div>
       </div>
     </section>
@@ -345,7 +346,7 @@
           </details>
           <details>
             <summary>Is there an Android version?</summary>
-            <p>We're currently rebuilding our Android release setup, so tester recruitment is paused for now. We'll post an update on <a href="/en/tester-android">this page</a> as soon as it's ready.</p>
+            <p>We're currently rebuilding our Android release setup, so tester recruitment is paused for now. We'll post an update on <a href="/en/tester-android/">this page</a> as soon as it's ready.</p>
           </details>
         </div>
       </div>
@@ -357,10 +358,10 @@
         <h2>Come on — let's turn your walk into an adventure.</h2>
         <p>Download it now and take your first step toward somewhere you've never been.</p>
         <div class="hero__cta" style="justify-content: center;">
-          <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="Download on the App Store">
+          <a class="app-badge" href="https://apps.apple.com/app/id6477759574" aria-label="Download on the App Store">
             <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
           </a>
-          <a class="btn" href="/en/tester-android" style="background:#fff;">Android (coming soon)</a>
+          <a class="btn" href="/en/tester-android/" style="background:#fff;">Android (coming soon)</a>
         </div>
       </div>
     </section>
@@ -401,7 +402,7 @@
             <ul>
               <li><a href="/en/privacy-policy/">Privacy Policy</a></li>
               <li><a href="#contact">Contact</a></li>
-              <li><a href="/en/tester-android">Android testers</a></li>
+              <li><a href="/en/tester-android/">Android testers</a></li>
             </ul>
           </div>
         </div>

--- a/en/privacy-policy/index.html
+++ b/en/privacy-policy/index.html
@@ -8,18 +8,10 @@
     <meta name="theme-color" content="#FACD00" />
     <meta name="robots" content="noindex" />
     <link rel="canonical" href="https://prokonjo.com/en/privacy-policy/" />
-    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/privacy-policy/" />
-    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/privacy-policy/" />
-    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/privacy-policy/" />
-    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/privacy-policy/" />
-    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/privacy-policy/" />
-    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/privacy-policy/" />
-    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/privacy-policy/" />
-    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/privacy-policy/" />
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@700;800;900&family=Noto+Sans+JP:wght@400;600;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="/css/styles.css" />
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
     <script>

--- a/en/tester-android/index.html
+++ b/en/tester-android/index.html
@@ -8,18 +8,10 @@
     <meta name="theme-color" content="#FACD00" />
     <meta name="robots" content="noindex" />
     <link rel="canonical" href="https://prokonjo.com/en/tester-android/" />
-    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/tester-android/" />
-    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/tester-android/" />
-    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/tester-android/" />
-    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/tester-android/" />
-    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/tester-android/" />
-    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/tester-android/" />
-    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/tester-android/" />
-    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/tester-android/" />
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@700;800;900&family=Noto+Sans+JP:wght@400;600;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="/css/styles.css" />
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
     <script>

--- a/es/index.html
+++ b/es/index.html
@@ -39,11 +39,12 @@
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
+    <link rel="preload" as="image" href="/assets/img/game-desc.jpg" fetchpriority="high" />
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@700;800;900&family=Noto+Sans+JP:wght@400;600;700&display=swap" rel="stylesheet" />
 
     <link rel="stylesheet" href="/css/styles.css" />
 
@@ -132,10 +133,10 @@
             Unos 15 minutos por partida. Un juego de paseos urbanos gratis y sin compras dentro de la app.
           </p>
           <div class="hero__cta">
-            <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="Descargar en el App Store">
+            <a class="app-badge" href="https://apps.apple.com/app/id6477759574" aria-label="Descargar en el App Store">
               <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/es-es?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
             </a>
-            <a class="btn btn--secondary" href="/es/tester-android">Android (próximamente)</a>
+            <a class="btn btn--secondary" href="/es/tester-android/">Android (próximamente)</a>
           </div>
           <p class="hero__note">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>
@@ -143,7 +144,7 @@
           </p>
         </div>
         <div class="hero__visual">
-          <img src="/assets/img/game-desc.jpg" alt="Imagen de juego de Explores" width="1200" height="676" />
+          <img src="/assets/img/game-desc.jpg" alt="Imagen de juego de Explores" width="1555" height="556" fetchpriority="high" />
         </div>
       </div>
     </section>
@@ -345,7 +346,7 @@
           </details>
           <details>
             <summary>¿Hay versión para Android?</summary>
-            <p>Ahora mismo estamos reconfigurando la publicación en Android, así que la búsqueda de probadores está pausada. Publicaremos una actualización en <a href="/es/tester-android">esta página</a> en cuanto esté lista.</p>
+            <p>Ahora mismo estamos reconfigurando la publicación en Android, así que la búsqueda de probadores está pausada. Publicaremos una actualización en <a href="/es/tester-android/">esta página</a> en cuanto esté lista.</p>
           </details>
         </div>
       </div>
@@ -357,10 +358,10 @@
         <h2>Venga, convierte tu paseo en una aventura.</h2>
         <p>Descárgalo ahora mismo y da el primer paso hacia un lugar que no conoces.</p>
         <div class="hero__cta" style="justify-content: center;">
-          <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="Descargar en el App Store">
+          <a class="app-badge" href="https://apps.apple.com/app/id6477759574" aria-label="Descargar en el App Store">
             <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/es-es?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
           </a>
-          <a class="btn" href="/es/tester-android" style="background:#fff;">Android (próximamente)</a>
+          <a class="btn" href="/es/tester-android/" style="background:#fff;">Android (próximamente)</a>
         </div>
       </div>
     </section>
@@ -401,7 +402,7 @@
             <ul>
               <li><a href="/es/privacy-policy/">Política de privacidad</a></li>
               <li><a href="#contact">Contacto</a></li>
-              <li><a href="/es/tester-android">Probadores de Android</a></li>
+              <li><a href="/es/tester-android/">Probadores de Android</a></li>
             </ul>
           </div>
         </div>

--- a/es/privacy-policy/index.html
+++ b/es/privacy-policy/index.html
@@ -8,18 +8,10 @@
     <meta name="theme-color" content="#FACD00" />
     <meta name="robots" content="noindex" />
     <link rel="canonical" href="https://prokonjo.com/es/privacy-policy/" />
-    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/privacy-policy/" />
-    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/privacy-policy/" />
-    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/privacy-policy/" />
-    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/privacy-policy/" />
-    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/privacy-policy/" />
-    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/privacy-policy/" />
-    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/privacy-policy/" />
-    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/privacy-policy/" />
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@700;800;900&family=Noto+Sans+JP:wght@400;600;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="/css/styles.css" />
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
     <script>

--- a/es/tester-android/index.html
+++ b/es/tester-android/index.html
@@ -8,18 +8,10 @@
     <meta name="theme-color" content="#FACD00" />
     <meta name="robots" content="noindex" />
     <link rel="canonical" href="https://prokonjo.com/es/tester-android/" />
-    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/tester-android/" />
-    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/tester-android/" />
-    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/tester-android/" />
-    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/tester-android/" />
-    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/tester-android/" />
-    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/tester-android/" />
-    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/tester-android/" />
-    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/tester-android/" />
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@700;800;900&family=Noto+Sans+JP:wght@400;600;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="/css/styles.css" />
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
     <script>

--- a/fr/index.html
+++ b/fr/index.html
@@ -39,11 +39,12 @@
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
+    <link rel="preload" as="image" href="/assets/img/game-desc.jpg" fetchpriority="high" />
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@700;800;900&family=Noto+Sans+JP:wght@400;600;700&display=swap" rel="stylesheet" />
 
     <link rel="stylesheet" href="/css/styles.css" />
 
@@ -132,10 +133,10 @@
             Environ 15 minutes par partie. Un jeu de balade urbaine gratuit, sans achats intégrés.
           </p>
           <div class="hero__cta">
-            <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="Télécharger dans l'App Store">
+            <a class="app-badge" href="https://apps.apple.com/app/id6477759574" aria-label="Télécharger dans l'App Store">
               <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/fr-fr?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
             </a>
-            <a class="btn btn--secondary" href="/fr/tester-android">Android (bientôt disponible)</a>
+            <a class="btn btn--secondary" href="/fr/tester-android/">Android (bientôt disponible)</a>
           </div>
           <p class="hero__note">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>
@@ -143,7 +144,7 @@
           </p>
         </div>
         <div class="hero__visual">
-          <img src="/assets/img/game-desc.jpg" alt="Aperçu d'une partie d'Explores" width="1200" height="676" />
+          <img src="/assets/img/game-desc.jpg" alt="Aperçu d'une partie d'Explores" width="1555" height="556" fetchpriority="high" />
         </div>
       </div>
     </section>
@@ -345,7 +346,7 @@
           </details>
           <details>
             <summary>Existe-t-il une version Android ?</summary>
-            <p>Nous reconfigurons actuellement notre publication Android ; le recrutement de testeurs est donc suspendu pour le moment. Nous publierons une mise à jour sur <a href="/fr/tester-android">cette page</a> dès que possible.</p>
+            <p>Nous reconfigurons actuellement notre publication Android ; le recrutement de testeurs est donc suspendu pour le moment. Nous publierons une mise à jour sur <a href="/fr/tester-android/">cette page</a> dès que possible.</p>
           </details>
         </div>
       </div>
@@ -357,10 +358,10 @@
         <h2>Allez, transformez la promenade en aventure.</h2>
         <p>Téléchargez l'appli dès maintenant et faites le premier pas vers l'inconnu.</p>
         <div class="hero__cta" style="justify-content: center;">
-          <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="Télécharger dans l'App Store">
+          <a class="app-badge" href="https://apps.apple.com/app/id6477759574" aria-label="Télécharger dans l'App Store">
             <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/fr-fr?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
           </a>
-          <a class="btn" href="/fr/tester-android" style="background:#fff;">Android (bientôt disponible)</a>
+          <a class="btn" href="/fr/tester-android/" style="background:#fff;">Android (bientôt disponible)</a>
         </div>
       </div>
     </section>
@@ -401,7 +402,7 @@
             <ul>
               <li><a href="/fr/privacy-policy/">Politique de confidentialité</a></li>
               <li><a href="#contact">Contact</a></li>
-              <li><a href="/fr/tester-android">Testeur Android</a></li>
+              <li><a href="/fr/tester-android/">Testeur Android</a></li>
             </ul>
           </div>
         </div>

--- a/fr/privacy-policy/index.html
+++ b/fr/privacy-policy/index.html
@@ -8,18 +8,10 @@
     <meta name="theme-color" content="#FACD00" />
     <meta name="robots" content="noindex" />
     <link rel="canonical" href="https://prokonjo.com/fr/privacy-policy/" />
-    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/privacy-policy/" />
-    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/privacy-policy/" />
-    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/privacy-policy/" />
-    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/privacy-policy/" />
-    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/privacy-policy/" />
-    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/privacy-policy/" />
-    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/privacy-policy/" />
-    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/privacy-policy/" />
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@700;800;900&family=Noto+Sans+JP:wght@400;600;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="/css/styles.css" />
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
     <script>

--- a/fr/tester-android/index.html
+++ b/fr/tester-android/index.html
@@ -8,18 +8,10 @@
     <meta name="theme-color" content="#FACD00" />
     <meta name="robots" content="noindex" />
     <link rel="canonical" href="https://prokonjo.com/fr/tester-android/" />
-    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/tester-android/" />
-    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/tester-android/" />
-    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/tester-android/" />
-    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/tester-android/" />
-    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/tester-android/" />
-    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/tester-android/" />
-    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/tester-android/" />
-    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/tester-android/" />
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@700;800;900&family=Noto+Sans+JP:wght@400;600;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="/css/styles.css" />
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
     <script>

--- a/index.html
+++ b/index.html
@@ -39,11 +39,12 @@
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
+    <link rel="preload" as="image" href="/assets/img/game-desc.jpg" fetchpriority="high" />
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@700;800;900&family=Noto+Sans+JP:wght@400;600;700&display=swap" rel="stylesheet" />
 
     <link rel="stylesheet" href="/css/styles.css" />
 
@@ -135,7 +136,7 @@
             <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="App Store からダウンロード">
               <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/ja-jp?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
             </a>
-            <a class="btn btn--secondary" href="/tester-android">Android（準備中）</a>
+            <a class="btn btn--secondary" href="/tester-android/">Android（準備中）</a>
           </div>
           <p class="hero__note">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>
@@ -143,7 +144,7 @@
           </p>
         </div>
         <div class="hero__visual">
-          <img src="/assets/img/game-desc.jpg" alt="エクスプロラーズのプレイイメージ" width="1200" height="676" />
+          <img src="/assets/img/game-desc.jpg" alt="エクスプロラーズのプレイイメージ" width="1555" height="556" fetchpriority="high" />
         </div>
       </div>
     </section>
@@ -345,7 +346,7 @@
           </details>
           <details>
             <summary>Android 版はありますか？</summary>
-            <p>現在、Android版は配信の準備を整え直しているところで、テスター募集を一時停止しています。準備が整い次第、<a href="/tester-android">こちらのページ</a>でご案内します。</p>
+            <p>現在、Android版は配信の準備を整え直しているところで、テスター募集を一時停止しています。準備が整い次第、<a href="/tester-android/">こちらのページ</a>でご案内します。</p>
           </details>
         </div>
       </div>
@@ -360,7 +361,7 @@
           <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="App Store からダウンロード">
             <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/ja-jp?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
           </a>
-          <a class="btn" href="/tester-android" style="background:#fff;">Android（準備中）</a>
+          <a class="btn" href="/tester-android/" style="background:#fff;">Android（準備中）</a>
         </div>
       </div>
     </section>
@@ -401,7 +402,7 @@
             <ul>
               <li><a href="/privacy-policy/">プライバシーポリシー</a></li>
               <li><a href="#contact">お問い合わせ</a></li>
-              <li><a href="/tester-android">Android テスター</a></li>
+              <li><a href="/tester-android/">Android テスター</a></li>
             </ul>
           </div>
         </div>

--- a/it/index.html
+++ b/it/index.html
@@ -39,11 +39,12 @@
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
+    <link rel="preload" as="image" href="/assets/img/game-desc.jpg" fetchpriority="high" />
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@700;800;900&family=Noto+Sans+JP:wght@400;600;700&display=swap" rel="stylesheet" />
 
     <link rel="stylesheet" href="/css/styles.css" />
 
@@ -132,10 +133,10 @@
             Una partita dura circa 15 minuti. Un gioco di passeggiate urbane gratis e senza acquisti in-app.
           </p>
           <div class="hero__cta">
-            <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="Scarica sull'App Store">
+            <a class="app-badge" href="https://apps.apple.com/app/id6477759574" aria-label="Scarica sull'App Store">
               <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/it-it?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
             </a>
-            <a class="btn btn--secondary" href="/it/tester-android">Android (in arrivo)</a>
+            <a class="btn btn--secondary" href="/it/tester-android/">Android (in arrivo)</a>
           </div>
           <p class="hero__note">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>
@@ -143,7 +144,7 @@
           </p>
         </div>
         <div class="hero__visual">
-          <img src="/assets/img/game-desc.jpg" alt="Immagine di gioco di Explores" width="1200" height="676" />
+          <img src="/assets/img/game-desc.jpg" alt="Immagine di gioco di Explores" width="1555" height="556" fetchpriority="high" />
         </div>
       </div>
     </section>
@@ -345,7 +346,7 @@
           </details>
           <details>
             <summary>Esiste la versione Android?</summary>
-            <p>Al momento stiamo riconfigurando la pubblicazione su Android, quindi il reclutamento dei tester è sospeso. Pubblicheremo un aggiornamento su <a href="/it/tester-android">questa pagina</a> appena sarà pronto.</p>
+            <p>Al momento stiamo riconfigurando la pubblicazione su Android, quindi il reclutamento dei tester è sospeso. Pubblicheremo un aggiornamento su <a href="/it/tester-android/">questa pagina</a> appena sarà pronto.</p>
           </details>
         </div>
       </div>
@@ -357,10 +358,10 @@
         <h2>Su, trasforma la passeggiata in avventura.</h2>
         <p>Scarica subito l'app e muovi il primo passo verso un luogo che non conosci.</p>
         <div class="hero__cta" style="justify-content: center;">
-          <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="Scarica sull'App Store">
+          <a class="app-badge" href="https://apps.apple.com/app/id6477759574" aria-label="Scarica sull'App Store">
             <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/it-it?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
           </a>
-          <a class="btn" href="/it/tester-android" style="background:#fff;">Android (in arrivo)</a>
+          <a class="btn" href="/it/tester-android/" style="background:#fff;">Android (in arrivo)</a>
         </div>
       </div>
     </section>
@@ -401,7 +402,7 @@
             <ul>
               <li><a href="/it/privacy-policy/">Informativa sulla privacy</a></li>
               <li><a href="#contact">Contatti</a></li>
-              <li><a href="/it/tester-android">Tester Android</a></li>
+              <li><a href="/it/tester-android/">Tester Android</a></li>
             </ul>
           </div>
         </div>

--- a/it/privacy-policy/index.html
+++ b/it/privacy-policy/index.html
@@ -8,18 +8,10 @@
     <meta name="theme-color" content="#FACD00" />
     <meta name="robots" content="noindex" />
     <link rel="canonical" href="https://prokonjo.com/it/privacy-policy/" />
-    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/privacy-policy/" />
-    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/privacy-policy/" />
-    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/privacy-policy/" />
-    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/privacy-policy/" />
-    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/privacy-policy/" />
-    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/privacy-policy/" />
-    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/privacy-policy/" />
-    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/privacy-policy/" />
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@700;800;900&family=Noto+Sans+JP:wght@400;600;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="/css/styles.css" />
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
     <script>

--- a/it/tester-android/index.html
+++ b/it/tester-android/index.html
@@ -8,18 +8,10 @@
     <meta name="theme-color" content="#FACD00" />
     <meta name="robots" content="noindex" />
     <link rel="canonical" href="https://prokonjo.com/it/tester-android/" />
-    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/tester-android/" />
-    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/tester-android/" />
-    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/tester-android/" />
-    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/tester-android/" />
-    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/tester-android/" />
-    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/tester-android/" />
-    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/tester-android/" />
-    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/tester-android/" />
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@700;800;900&family=Noto+Sans+JP:wght@400;600;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="/css/styles.css" />
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
     <script>

--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -8,18 +8,10 @@
     <meta name="theme-color" content="#FACD00" />
     <meta name="robots" content="noindex" />
     <link rel="canonical" href="https://prokonjo.com/privacy-policy/" />
-    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/privacy-policy/" />
-    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/privacy-policy/" />
-    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/privacy-policy/" />
-    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/privacy-policy/" />
-    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/privacy-policy/" />
-    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/privacy-policy/" />
-    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/privacy-policy/" />
-    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/privacy-policy/" />
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@700;800;900&family=Noto+Sans+JP:wght@400;600;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="/css/styles.css" />
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
     <script>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://prokonjo.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://prokonjo.com/</loc>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://prokonjo.com/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://prokonjo.com/en/"/>
+    <xhtml:link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://prokonjo.com/it/"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://prokonjo.com/es/"/>
+    <xhtml:link rel="alternate" hreflang="th" href="https://prokonjo.com/th/"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://prokonjo.com/"/>
+  </url>
+  <url>
+    <loc>https://prokonjo.com/en/</loc>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://prokonjo.com/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://prokonjo.com/en/"/>
+    <xhtml:link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://prokonjo.com/it/"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://prokonjo.com/es/"/>
+    <xhtml:link rel="alternate" hreflang="th" href="https://prokonjo.com/th/"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://prokonjo.com/"/>
+  </url>
+  <url>
+    <loc>https://prokonjo.com/zh/</loc>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://prokonjo.com/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://prokonjo.com/en/"/>
+    <xhtml:link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://prokonjo.com/it/"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://prokonjo.com/es/"/>
+    <xhtml:link rel="alternate" hreflang="th" href="https://prokonjo.com/th/"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://prokonjo.com/"/>
+  </url>
+  <url>
+    <loc>https://prokonjo.com/fr/</loc>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://prokonjo.com/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://prokonjo.com/en/"/>
+    <xhtml:link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://prokonjo.com/it/"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://prokonjo.com/es/"/>
+    <xhtml:link rel="alternate" hreflang="th" href="https://prokonjo.com/th/"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://prokonjo.com/"/>
+  </url>
+  <url>
+    <loc>https://prokonjo.com/it/</loc>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://prokonjo.com/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://prokonjo.com/en/"/>
+    <xhtml:link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://prokonjo.com/it/"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://prokonjo.com/es/"/>
+    <xhtml:link rel="alternate" hreflang="th" href="https://prokonjo.com/th/"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://prokonjo.com/"/>
+  </url>
+  <url>
+    <loc>https://prokonjo.com/es/</loc>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://prokonjo.com/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://prokonjo.com/en/"/>
+    <xhtml:link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://prokonjo.com/it/"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://prokonjo.com/es/"/>
+    <xhtml:link rel="alternate" hreflang="th" href="https://prokonjo.com/th/"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://prokonjo.com/"/>
+  </url>
+  <url>
+    <loc>https://prokonjo.com/th/</loc>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://prokonjo.com/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://prokonjo.com/en/"/>
+    <xhtml:link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://prokonjo.com/it/"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://prokonjo.com/es/"/>
+    <xhtml:link rel="alternate" hreflang="th" href="https://prokonjo.com/th/"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://prokonjo.com/"/>
+  </url>
+</urlset>

--- a/tester-android/index.html
+++ b/tester-android/index.html
@@ -8,18 +8,10 @@
     <meta name="theme-color" content="#FACD00" />
     <meta name="robots" content="noindex" />
     <link rel="canonical" href="https://prokonjo.com/tester-android/" />
-    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/tester-android/" />
-    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/tester-android/" />
-    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/tester-android/" />
-    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/tester-android/" />
-    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/tester-android/" />
-    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/tester-android/" />
-    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/tester-android/" />
-    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/tester-android/" />
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@700;800;900&family=Noto+Sans+JP:wght@400;600;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="/css/styles.css" />
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
     <script>

--- a/th/index.html
+++ b/th/index.html
@@ -39,11 +39,12 @@
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
+    <link rel="preload" as="image" href="/assets/img/game-desc.jpg" fetchpriority="high" />
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@700;800;900&family=Noto+Sans+JP:wght@400;600;700&display=swap" rel="stylesheet" />
 
     <link rel="stylesheet" href="/css/styles.css" />
 
@@ -132,10 +133,10 @@
             เล่นรอบละราว 15 นาที เกมเดินสำรวจเมืองที่ฟรีและไม่มีระบบเติมเงิน
           </p>
           <div class="hero__cta">
-            <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="ดาวน์โหลดบน App Store">
+            <a class="app-badge" href="https://apps.apple.com/app/id6477759574" aria-label="ดาวน์โหลดบน App Store">
               <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/th-th?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
             </a>
-            <a class="btn btn--secondary" href="/th/tester-android">Android (เร็ว ๆ นี้)</a>
+            <a class="btn btn--secondary" href="/th/tester-android/">Android (เร็ว ๆ นี้)</a>
           </div>
           <p class="hero__note">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>
@@ -143,7 +144,7 @@
           </p>
         </div>
         <div class="hero__visual">
-          <img src="/assets/img/game-desc.jpg" alt="ภาพตัวอย่างการเล่น Explores" width="1200" height="676" />
+          <img src="/assets/img/game-desc.jpg" alt="ภาพตัวอย่างการเล่น Explores" width="1555" height="556" fetchpriority="high" />
         </div>
       </div>
     </section>
@@ -345,7 +346,7 @@
           </details>
           <details>
             <summary>มีเวอร์ชัน Android ไหม?</summary>
-            <p>ขณะนี้เรากำลังจัดเตรียมการเผยแพร่บน Android ใหม่ จึงหยุดรับสมัครผู้ทดสอบชั่วคราว เราจะแจ้งให้ทราบที่<a href="/th/tester-android">หน้านี้</a>เมื่อพร้อม</p>
+            <p>ขณะนี้เรากำลังจัดเตรียมการเผยแพร่บน Android ใหม่ จึงหยุดรับสมัครผู้ทดสอบชั่วคราว เราจะแจ้งให้ทราบที่<a href="/th/tester-android/">หน้านี้</a>เมื่อพร้อม</p>
           </details>
         </div>
       </div>
@@ -357,10 +358,10 @@
         <h2>มาเปลี่ยนการเดินเล่นให้เป็นการผจญภัยกันเถอะ</h2>
         <p>ดาวน์โหลดเลยตอนนี้ แล้วก้าวออกไปสู่สถานที่ที่คุณไม่เคยรู้จัก</p>
         <div class="hero__cta" style="justify-content: center;">
-          <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="ดาวน์โหลดบน App Store">
+          <a class="app-badge" href="https://apps.apple.com/app/id6477759574" aria-label="ดาวน์โหลดบน App Store">
             <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/th-th?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
           </a>
-          <a class="btn" href="/th/tester-android" style="background:#fff;">Android (เร็ว ๆ นี้)</a>
+          <a class="btn" href="/th/tester-android/" style="background:#fff;">Android (เร็ว ๆ นี้)</a>
         </div>
       </div>
     </section>
@@ -401,7 +402,7 @@
             <ul>
               <li><a href="/th/privacy-policy/">นโยบายความเป็นส่วนตัว</a></li>
               <li><a href="#contact">ติดต่อเรา</a></li>
-              <li><a href="/th/tester-android">ผู้ทดสอบ Android</a></li>
+              <li><a href="/th/tester-android/">ผู้ทดสอบ Android</a></li>
             </ul>
           </div>
         </div>

--- a/th/privacy-policy/index.html
+++ b/th/privacy-policy/index.html
@@ -8,18 +8,10 @@
     <meta name="theme-color" content="#FACD00" />
     <meta name="robots" content="noindex" />
     <link rel="canonical" href="https://prokonjo.com/th/privacy-policy/" />
-    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/privacy-policy/" />
-    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/privacy-policy/" />
-    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/privacy-policy/" />
-    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/privacy-policy/" />
-    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/privacy-policy/" />
-    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/privacy-policy/" />
-    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/privacy-policy/" />
-    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/privacy-policy/" />
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@700;800;900&family=Noto+Sans+JP:wght@400;600;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="/css/styles.css" />
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
     <script>

--- a/th/tester-android/index.html
+++ b/th/tester-android/index.html
@@ -8,18 +8,10 @@
     <meta name="theme-color" content="#FACD00" />
     <meta name="robots" content="noindex" />
     <link rel="canonical" href="https://prokonjo.com/th/tester-android/" />
-    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/tester-android/" />
-    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/tester-android/" />
-    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/tester-android/" />
-    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/tester-android/" />
-    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/tester-android/" />
-    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/tester-android/" />
-    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/tester-android/" />
-    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/tester-android/" />
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@700;800;900&family=Noto+Sans+JP:wght@400;600;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="/css/styles.css" />
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
     <script>

--- a/zh/index.html
+++ b/zh/index.html
@@ -39,11 +39,12 @@
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
+    <link rel="preload" as="image" href="/assets/img/game-desc.jpg" fetchpriority="high" />
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@700;800;900&family=Noto+Sans+JP:wght@400;600;700&display=swap" rel="stylesheet" />
 
     <link rel="stylesheet" href="/css/styles.css" />
 
@@ -132,10 +133,10 @@
             一局約 15 分鐘。免費、無內購的街頭探索遊戲。
           </p>
           <div class="hero__cta">
-            <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="從 App Store 下載">
+            <a class="app-badge" href="https://apps.apple.com/app/id6477759574" aria-label="從 App Store 下載">
               <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/zh-tw?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
             </a>
-            <a class="btn btn--secondary" href="/zh/tester-android">Android（準備中）</a>
+            <a class="btn btn--secondary" href="/zh/tester-android/">Android（準備中）</a>
           </div>
           <p class="hero__note">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>
@@ -143,7 +144,7 @@
           </p>
         </div>
         <div class="hero__visual">
-          <img src="/assets/img/game-desc.jpg" alt="Explores 的遊玩示意圖" width="1200" height="676" />
+          <img src="/assets/img/game-desc.jpg" alt="Explores 的遊玩示意圖" width="1555" height="556" fetchpriority="high" />
         </div>
       </div>
     </section>
@@ -345,7 +346,7 @@
           </details>
           <details>
             <summary>有 Android 版嗎？</summary>
-            <p>目前正在重新整理 Android 的發佈環境，暫停招募測試者。準備就緒後將於<a href="/zh/tester-android">這個頁面</a>公布。</p>
+            <p>目前正在重新整理 Android 的發佈環境，暫停招募測試者。準備就緒後將於<a href="/zh/tester-android/">這個頁面</a>公布。</p>
           </details>
         </div>
       </div>
@@ -357,10 +358,10 @@
         <h2>來吧，把散步變成冒險。</h2>
         <p>現在就下載，踏出走向陌生地方的第一步。</p>
         <div class="hero__cta" style="justify-content: center;">
-          <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="從 App Store 下載">
+          <a class="app-badge" href="https://apps.apple.com/app/id6477759574" aria-label="從 App Store 下載">
             <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/zh-tw?size=250x83&amp;releaseDate=1715040000" alt="Download on the App Store" />
           </a>
-          <a class="btn" href="/zh/tester-android" style="background:#fff;">Android（準備中）</a>
+          <a class="btn" href="/zh/tester-android/" style="background:#fff;">Android（準備中）</a>
         </div>
       </div>
     </section>
@@ -401,7 +402,7 @@
             <ul>
               <li><a href="/zh/privacy-policy/">隱私權政策</a></li>
               <li><a href="#contact">聯絡我們</a></li>
-              <li><a href="/zh/tester-android">Android 測試者</a></li>
+              <li><a href="/zh/tester-android/">Android 測試者</a></li>
             </ul>
           </div>
         </div>

--- a/zh/privacy-policy/index.html
+++ b/zh/privacy-policy/index.html
@@ -8,18 +8,10 @@
     <meta name="theme-color" content="#FACD00" />
     <meta name="robots" content="noindex" />
     <link rel="canonical" href="https://prokonjo.com/zh/privacy-policy/" />
-    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/privacy-policy/" />
-    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/privacy-policy/" />
-    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/privacy-policy/" />
-    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/privacy-policy/" />
-    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/privacy-policy/" />
-    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/privacy-policy/" />
-    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/privacy-policy/" />
-    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/privacy-policy/" />
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@700;800;900&family=Noto+Sans+JP:wght@400;600;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="/css/styles.css" />
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
     <script>

--- a/zh/tester-android/index.html
+++ b/zh/tester-android/index.html
@@ -8,18 +8,10 @@
     <meta name="theme-color" content="#FACD00" />
     <meta name="robots" content="noindex" />
     <link rel="canonical" href="https://prokonjo.com/zh/tester-android/" />
-    <link rel="alternate" hreflang="ja" href="https://prokonjo.com/tester-android/" />
-    <link rel="alternate" hreflang="en" href="https://prokonjo.com/en/tester-android/" />
-    <link rel="alternate" hreflang="zh-Hant" href="https://prokonjo.com/zh/tester-android/" />
-    <link rel="alternate" hreflang="fr" href="https://prokonjo.com/fr/tester-android/" />
-    <link rel="alternate" hreflang="it" href="https://prokonjo.com/it/tester-android/" />
-    <link rel="alternate" hreflang="es" href="https://prokonjo.com/es/tester-android/" />
-    <link rel="alternate" hreflang="th" href="https://prokonjo.com/th/tester-android/" />
-    <link rel="alternate" hreflang="x-default" href="https://prokonjo.com/tester-android/" />
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;700;800;900&family=Noto+Sans+JP:wght@400;500;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@700;800;900&family=Noto+Sans+JP:wght@400;600;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="/css/styles.css" />
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-P3YYZEG46Z"></script>
     <script>


### PR DESCRIPTION
## 概要
LP の SEO 監査（5観点・全7言語）で出た **技術/クロール/CWV系の確実な改善**を先行適用するPRです（コンテンツ・ブランド系は別PR）。土台（canonical・hreflang・OGP）は元々良好で、ここでは欠けていた配管と速度を埋めます。

## 変更
**新規ファイル**
- `sitemap.xml` — インデックス対象の7言語ホームを相互hreflang付きで列挙（海外6言語が発見されにくかった最大要因の解消）
- `robots.txt` — `Allow: /` ＋ `Sitemap:` 行でクローラーを誘導
- `404.html` — ブランド付き・noindex・7言語ホームへの導線

**既存HTML（全7言語）**
- ヒーロー画像 LCP: `preload` ＋ `fetchpriority="high"` 追加、**寸法誤りを修正**（1200×676 → 実寸1555×556、CLS解消）
- Google Fonts を実使用ウェイトに削減（未使用の500を除去・600を追加してfaux-bold解消）
- 海外版 App Store リンクを地域自動振り分け型 `apps.apple.com/app/id…` に（従来はJP固定で海外ユーザーが弾かれていた）
- tester-android 内部リンクに末尾スラッシュ（301リダイレクト解消）
- noindex 14ページの不活性 hreflang を削除

## 効果（想定）
- 海外6言語ページのインデックス促進（sitemap）／計測の前提整備
- モバイル LCP・CLS 改善（ヒーロー）／フォント転送量削減
- 海外プレイ導線のコンバージョン改善（地域別ストア）

## 補足
- **Google Search Console 未設定**。マージ後にドメイン認証（DNS TXT）→ sitemap 送信が必要（手順は別途用意）。
- 画像のバイナリ最適化（member PNG/未使用背景の削減）と多言語コンテンツ最適化（JSON-LD/FAQPage/キーワード/ブランド統一）は**別PRで対応予定**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
