### PR TITLE
feat(lp): SEO構造化データ＋コンテンツ/ブランド統一（全7言語・PR-B）

### DIFF
--- a/en/index.html
+++ b/en/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <title>Explores｜The walking game that turns strolls into adventures</title>
-    <meta name="description" content="Explores is the walking game that turns an ordinary stroll into an adventure. Use a photo as your only clue and walk to a place you've never been. About 15 minutes per round. Free, with no in-app purchases." />
+    <meta name="description" content="Explores is a location-based GPS walking game that turns a stroll into an adventure: one photo is your clue. About 15 min a round. Free, no in-app purchases." />
     <meta name="author" content="Prokonjo" />
     <meta name="theme-color" content="#FACD00" />
     <link rel="canonical" href="https://prokonjo.com/en/" />
@@ -29,13 +29,21 @@
     <meta property="og:image:type" content="image/jpeg" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Explores — the location-based walking game that turns a stroll into an adventure" />
     <meta property="og:locale" content="en_US" />
+    <meta property="og:locale:alternate" content="ja_JP" />
+    <meta property="og:locale:alternate" content="zh_TW" />
+    <meta property="og:locale:alternate" content="fr_FR" />
+    <meta property="og:locale:alternate" content="it_IT" />
+    <meta property="og:locale:alternate" content="es_ES" />
+    <meta property="og:locale:alternate" content="th_TH" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Explores｜The walking game that turns strolls into adventures" />
     <meta name="twitter:description" content="A walking game where a single photo is your clue to reach a place you've never been. About 15 minutes per round. Free, with no in-app purchases." />
     <meta name="twitter:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+    <meta name="twitter:image:alt" content="Explores — the location-based walking game that turns a stroll into an adventure" />
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
@@ -52,22 +60,19 @@
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
-        "@type": "MobileApplication",
-        "name": "Explores",
-        "description": "The walking game that turns a stroll into an adventure. Use a photo as your clue to reach a place you've never been — an exploration experience that takes about 15 minutes per round.",
-        "url": "https://prokonjo.com/",
-        "applicationCategory": "GameApplication",
-        "operatingSystem": "iOS",
-        "offers": {
-          "@type": "Offer",
-          "price": "0",
-          "priceCurrency": "JPY"
-        },
-        "publisher": {
-          "@type": "Organization",
-          "name": "Prokonjo",
-          "url": "https://prokonjo.com/"
-        }
+        "@graph": [
+          { "@type": "Organization", "@id": "https://prokonjo.com/#org", "name": "Prokonjo", "url": "https://prokonjo.com/", "logo": "https://prokonjo.com/assets/img/game-logo.png", "sameAs": ["https://x.com/geek_pjt"] },
+          { "@type": "WebSite", "@id": "https://prokonjo.com/en/#website", "url": "https://prokonjo.com/en/", "name": "Explores", "inLanguage": "en", "publisher": { "@id": "https://prokonjo.com/#org" } },
+          { "@type": "MobileApplication", "@id": "https://prokonjo.com/en/#app", "name": "Explores", "description": "Explores is a location-based GPS walking game that turns a stroll into an adventure: one photo is your clue. About 15 min a round. Free, no in-app purchases.", "url": "https://prokonjo.com/en/", "inLanguage": "en", "applicationCategory": "GameApplication", "operatingSystem": "iOS", "installUrl": "https://apps.apple.com/app/id6477759574", "downloadUrl": "https://apps.apple.com/app/id6477759574", "screenshot": ["https://prokonjo.com/assets/img/game-play0.png","https://prokonjo.com/assets/img/game-play1.png","https://prokonjo.com/assets/img/game-play2.png"], "award": ["技育博 企業賞","和歌山イノベーションプログラミングコンテスト 最優秀賞","e-ZUKAスマートアプリコンテスト2023 飯塚市長賞・企業賞"], "offers": { "@type": "Offer", "price": "0", "priceCurrency": "JPY" }, "author": { "@id": "https://prokonjo.com/#org" }, "publisher": { "@id": "https://prokonjo.com/#org" } },
+          { "@type": "FAQPage", "@id": "https://prokonjo.com/en/#faq", "inLanguage": "en", "mainEntity": [
+            { "@type": "Question", "name": "Is it really free? Are there any in-app purchases?", "acceptedAnswer": { "@type": "Answer", "text": "It's completely free. There are no in-app purchases of any kind — no gacha, no subscriptions. And for now, we're not showing ads either." } },
+            { "@type": "Question", "name": "How long does one round take?", "acceptedAnswer": { "@type": "Answer", "text": "You can choose from options like 15, 20, or 30 minutes to match your mood. It works just as well for a quick break as for a weekend when you want to really put in the miles." } },
+            { "@type": "Question", "name": "Where can I play?", "acceptedAnswer": { "@type": "Answer", "text": "Pretty much anywhere in town. Based on your GPS location, the game automatically generates goals within walking distance of where you are." } },
+            { "@type": "Question", "name": "How much data and battery does it use?", "acceptedAnswer": { "@type": "Answer", "text": "Because it tracks your location continuously, longer sessions will drain your battery faster. Data use is mostly for displaying the map and isn't excessive." } },
+            { "@type": "Question", "name": "Any safety tips for playing?", "acceptedAnswer": { "@type": "Answer", "text": "Please take great care not to use your phone while walking. Stop before crosswalks, avoid dark or deserted areas, and always follow the basic safety rules of any walk." } },
+            { "@type": "Question", "name": "Is there an Android version?", "acceptedAnswer": { "@type": "Answer", "text": "We're currently rebuilding our Android release setup, so tester recruitment is paused for now. We'll post an update on this page as soon as it's ready." } }
+          ] }
+        ]
       }
     </script>
 
@@ -144,7 +149,7 @@
           </p>
         </div>
         <div class="hero__visual">
-          <img src="/assets/img/game-desc.jpg" alt="A look at Explores gameplay" width="1555" height="556" fetchpriority="high" />
+          <img src="/assets/img/game-desc.jpg" alt="Explores — location-based walking game gameplay" width="1555" height="556" fetchpriority="high" />
         </div>
       </div>
     </section>
@@ -207,19 +212,19 @@
         <div class="steps">
           <div class="step">
             <div class="step__num">1</div>
-            <img class="step__img" src="/assets/img/game-play0.png" alt="Time selection screen" loading="lazy" />
+            <img class="step__img" src="/assets/img/game-play0.png" alt="Explores walking game — time selection screen" loading="lazy" />
             <h3>Pick your time</h3>
             <p>Choose how long you want to walk. "15 minutes," "30 minutes" — whatever suits your mood.</p>
           </div>
           <div class="step">
             <div class="step__num">2</div>
-            <img class="step__img" src="/assets/img/game-play1.png" alt="Screen for reviewing the photo and map near the destination" loading="lazy" />
+            <img class="step__img" src="/assets/img/game-play1.png" alt="Explores walking game — photo and map of the destination to memorize" loading="lazy" />
             <h3>Memorize the destination</h3>
             <p>Study the photo and map around your destination carefully before you start. Once the round begins, they're hidden.</p>
           </div>
           <div class="step">
             <div class="step__num">3</div>
-            <img class="step__img" src="/assets/img/game-play2.png" alt="In-game screen while exploring" loading="lazy" />
+            <img class="step__img" src="/assets/img/game-play2.png" alt="Explores walking game — in-game screen while exploring on foot" loading="lazy" />
             <h3>Walk from memory</h3>
             <p>With only the remaining time and distance to guide you, walk to your destination. "There — that's the view from the photo!"</p>
           </div>

--- a/en/tester-android/index.html
+++ b/en/tester-android/index.html
@@ -8,6 +8,22 @@
     <meta name="theme-color" content="#FACD00" />
     <meta name="robots" content="noindex" />
     <link rel="canonical" href="https://prokonjo.com/en/tester-android/" />
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Explores" />
+    <meta property="og:title" content="Explores Android Tester Recruitment (Coming Soon)" />
+    <meta property="og:description" content="Ahead of our Google Play launch, we're recruiting Android testers for Explores. Sign-ups are paused while we prepare — check back soon." />
+    <meta property="og:url" content="https://prokonjo.com/en/tester-android/" />
+    <meta property="og:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+    <meta property="og:locale" content="en_US" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Explores Android Tester Recruitment (Coming Soon)" />
+    <meta name="twitter:description" content="Ahead of our Google Play launch, we're recruiting Android testers for Explores. Sign-ups are paused while we prepare — check back soon." />
+    <meta name="twitter:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -64,7 +80,7 @@
 
     <section class="page-header">
       <div class="container">
-        <h1>Android Testers (Coming Soon)</h1>
+        <h1>Explores Android Tester Recruitment (Coming Soon)</h1>
         <p class="page-header__lead">Ahead of our Google Play launch, we're looking for people to play Explores early on Android. Join in just 3 steps!</p>
       </div>
     </section>

--- a/es/index.html
+++ b/es/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <title>Explores｜El juego de paseos urbanos que convierte tu caminata en aventura</title>
-    <meta name="description" content="Explores, el juego de paseos urbanos que convierte tu caminata en una aventura. Guíate por una foto y camina hacia lugares que no conoces. Unos 15 minutos por partida, gratis y sin compras dentro de la app." />
+    <meta name="description" content="Explores, juego de caminar por geolocalización (GPS) que convierte tu paseo en aventura. Guíate por una foto, ~15 min por partida. Gratis y sin compras." />
     <meta name="author" content="Prokonjo" />
     <meta name="theme-color" content="#FACD00" />
     <link rel="canonical" href="https://prokonjo.com/es/" />
@@ -30,12 +30,20 @@
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:locale" content="es_ES" />
+    <meta property="og:locale:alternate" content="ja_JP" />
+    <meta property="og:locale:alternate" content="en_US" />
+    <meta property="og:locale:alternate" content="zh_TW" />
+    <meta property="og:locale:alternate" content="fr_FR" />
+    <meta property="og:locale:alternate" content="it_IT" />
+    <meta property="og:locale:alternate" content="th_TH" />
+    <meta property="og:image:alt" content="Explores — convierte tu paseo en una aventura" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Explores｜El juego de paseos urbanos que convierte tu caminata en aventura" />
     <meta name="twitter:description" content="Un juego de paseos urbanos en el que te guías por una foto para caminar hacia lugares que no conoces. Unos 15 minutos por partida, gratis y sin compras dentro de la app." />
     <meta name="twitter:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+    <meta name="twitter:image:alt" content="Explores — convierte tu paseo en una aventura" />
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
@@ -52,22 +60,19 @@
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
-        "@type": "MobileApplication",
-        "name": "Explores",
-        "description": "Un juego de paseos urbanos que convierte tu caminata en una aventura. Te guías por una foto para caminar hacia lugares que no conoces: una experiencia de exploración de unos 15 minutos por partida.",
-        "url": "https://prokonjo.com/",
-        "applicationCategory": "GameApplication",
-        "operatingSystem": "iOS",
-        "offers": {
-          "@type": "Offer",
-          "price": "0",
-          "priceCurrency": "JPY"
-        },
-        "publisher": {
-          "@type": "Organization",
-          "name": "Prokonjo",
-          "url": "https://prokonjo.com/"
-        }
+        "@graph": [
+          { "@type": "Organization", "@id": "https://prokonjo.com/#org", "name": "Prokonjo", "url": "https://prokonjo.com/", "logo": "https://prokonjo.com/assets/img/game-logo.png", "sameAs": ["https://x.com/geek_pjt"] },
+          { "@type": "WebSite", "@id": "https://prokonjo.com/es/#website", "url": "https://prokonjo.com/es/", "name": "Explores", "inLanguage": "es", "publisher": { "@id": "https://prokonjo.com/#org" } },
+          { "@type": "MobileApplication", "@id": "https://prokonjo.com/es/#app", "name": "Explores", "description": "Explores, juego de caminar por geolocalización (GPS) que convierte tu paseo en aventura. Guíate por una foto, ~15 min por partida. Gratis y sin compras.", "url": "https://prokonjo.com/es/", "inLanguage": "es", "applicationCategory": "GameApplication", "operatingSystem": "iOS", "installUrl": "https://apps.apple.com/app/id6477759574", "downloadUrl": "https://apps.apple.com/app/id6477759574", "screenshot": ["https://prokonjo.com/assets/img/game-play0.png","https://prokonjo.com/assets/img/game-play1.png","https://prokonjo.com/assets/img/game-play2.png"], "award": ["技育博 企業賞","和歌山イノベーションプログラミングコンテスト 最優秀賞","e-ZUKAスマートアプリコンテスト2023 飯塚市長賞・企業賞"], "offers": { "@type": "Offer", "price": "0", "priceCurrency": "JPY" }, "author": { "@id": "https://prokonjo.com/#org" }, "publisher": { "@id": "https://prokonjo.com/#org" } },
+          { "@type": "FAQPage", "@id": "https://prokonjo.com/es/#faq", "inLanguage": "es", "mainEntity": [
+            { "@type": "Question", "name": "¿De verdad es gratis? ¿Hay compras dentro de la app?", "acceptedAnswer": { "@type": "Answer", "text": "Es totalmente gratis. No hay ningún tipo de compra dentro de la app, ni gachas ni suscripciones. De momento tampoco mostramos anuncios." } },
+            { "@type": "Question", "name": "¿Cuánto dura una partida?", "acceptedAnswer": { "@type": "Answer", "text": "Puedes elegir entre 15, 20 o 30 minutos, según lo que te apetezca en ese momento. Sirve igual para un huequito corto que para un fin de semana en el que quieras caminar a tope." } },
+            { "@type": "Question", "name": "¿Dónde se puede jugar?", "acceptedAnswer": { "@type": "Answer", "text": "En general puedes disfrutarlo en cualquier zona urbana. A partir de tu información de GPS, se genera automáticamente una meta dentro de un radio al que puedas llegar caminando desde tu ubicación actual." } },
+            { "@type": "Question", "name": "¿Cuánto consume de datos y batería?", "acceptedAnswer": { "@type": "Answer", "text": "Como obtiene la ubicación de forma continua, jugar durante mucho tiempo tiende a gastar batería. El consumo de datos es sobre todo el de mostrar el mapa, así que no es excesivo." } },
+            { "@type": "Question", "name": "¿Qué precauciones debo tomar para jugar con seguridad?", "acceptedAnswer": { "@type": "Answer", "text": "Ten muchísimo cuidado de no manejar el móvil mientras caminas. Detente antes de cruzar los pasos de peatones, evita las calles oscuras y las zonas solitarias y, en general, respeta siempre las reglas básicas de seguridad al pasear." } },
+            { "@type": "Question", "name": "¿Hay versión para Android?", "acceptedAnswer": { "@type": "Answer", "text": "Ahora mismo estamos reconfigurando la publicación en Android, así que la búsqueda de probadores está pausada. Publicaremos una actualización en esta página en cuanto esté lista." } }
+          ] }
+        ]
       }
     </script>
 
@@ -144,7 +149,7 @@
           </p>
         </div>
         <div class="hero__visual">
-          <img src="/assets/img/game-desc.jpg" alt="Imagen de juego de Explores" width="1555" height="556" fetchpriority="high" />
+          <img src="/assets/img/game-desc.jpg" alt="Explores — juego de caminar por geolocalización (GPS) que convierte tu paseo en aventura" width="1555" height="556" fetchpriority="high" />
         </div>
       </div>
     </section>
@@ -207,19 +212,19 @@
         <div class="steps">
           <div class="step">
             <div class="step__num">1</div>
-            <img class="step__img" src="/assets/img/game-play0.png" alt="Pantalla de selección de tiempo" loading="lazy" />
+            <img class="step__img" src="/assets/img/game-play0.png" alt="Explores — pantalla de selección de tiempo del juego de caminar por geolocalización" loading="lazy" />
             <h3>Elige el tiempo</h3>
             <p>Elige cuánto quieres caminar. "15 minutos", "30 minutos"... lo que te apetezca en ese momento.</p>
           </div>
           <div class="step">
             <div class="step__num">2</div>
-            <img class="step__img" src="/assets/img/game-play1.png" alt="Pantalla para revisar las fotos y el mapa de los alrededores del destino" loading="lazy" />
+            <img class="step__img" src="/assets/img/game-play1.png" alt="Explores — pantalla para memorizar las fotos y el mapa del destino, juego de caminar por GPS" loading="lazy" />
             <h3>Memoriza el destino</h3>
             <p>Antes de empezar la partida, fíjate bien en las fotos y el mapa de los alrededores del destino. En cuanto empieces, desaparecen.</p>
           </div>
           <div class="step">
             <div class="step__num">3</div>
-            <img class="step__img" src="/assets/img/game-play2.png" alt="Pantalla del juego durante la exploración" loading="lazy" />
+            <img class="step__img" src="/assets/img/game-play2.png" alt="Explores — pantalla del juego durante la exploración a pie por geolocalización" loading="lazy" />
             <h3>Camina de memoria</h3>
             <p>Guíate solo por el tiempo restante y la distancia para llegar al destino. "¡Ey, ese es el paisaje de la foto!"</p>
           </div>

--- a/es/tester-android/index.html
+++ b/es/tester-android/index.html
@@ -8,6 +8,22 @@
     <meta name="theme-color" content="#FACD00" />
     <meta name="robots" content="noindex" />
     <link rel="canonical" href="https://prokonjo.com/es/tester-android/" />
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Explores" />
+    <meta property="og:title" content="Buscamos testers de Android de Explores (próximamente)" />
+    <meta property="og:description" content="Reclutamiento de testers de Android de Explores, el juego de caminar por geolocalización (GPS). La versión de Android está en preparación; te avisaremos en cuanto abramos las inscripciones." />
+    <meta property="og:url" content="https://prokonjo.com/es/tester-android/" />
+    <meta property="og:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+    <meta property="og:locale" content="es_ES" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Buscamos testers de Android de Explores (próximamente)" />
+    <meta name="twitter:description" content="Reclutamiento de testers de Android de Explores, el juego de caminar por geolocalización (GPS). La versión de Android está en preparación; te avisaremos en cuanto abramos las inscripciones." />
+    <meta name="twitter:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -64,7 +80,7 @@
 
     <section class="page-header">
       <div class="container">
-        <h1>Testers de Android (próximamente)</h1>
+        <h1>Buscamos testers de Android de Explores (próximamente)</h1>
         <p class="page-header__lead">De cara al lanzamiento en Google Play, buscamos personas que quieran probar Explores en Android antes que nadie. ¡Apúntate en solo 3 pasos!</p>
       </div>
     </section>

--- a/fr/index.html
+++ b/fr/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <title>Explores｜Le jeu de balade urbaine qui transforme vos promenades en aventures</title>
-    <meta name="description" content="Explores, le jeu de balade urbaine qui transforme la promenade en aventure. Guidé par des photos, partez à pied vers des lieux inconnus. Environ 15 min par partie, gratuit, sans achats intégrés." />
+    <meta name="description" content="Explores, le jeu de balade urbaine qui transforme la promenade en aventure. Jeu de marche en géolocalisation (GPS), gratuit, sans achats intégrés." />
     <meta name="author" content="Prokonjo" />
     <meta name="theme-color" content="#FACD00" />
     <link rel="canonical" href="https://prokonjo.com/fr/" />
@@ -29,13 +29,21 @@
     <meta property="og:image:type" content="image/jpeg" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Explores — le jeu de balade urbaine qui transforme la promenade en aventure" />
     <meta property="og:locale" content="fr_FR" />
+    <meta property="og:locale:alternate" content="ja_JP" />
+    <meta property="og:locale:alternate" content="en_US" />
+    <meta property="og:locale:alternate" content="zh_TW" />
+    <meta property="og:locale:alternate" content="it_IT" />
+    <meta property="og:locale:alternate" content="es_ES" />
+    <meta property="og:locale:alternate" content="th_TH" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Explores｜Le jeu de balade urbaine qui transforme vos promenades en aventures" />
     <meta name="twitter:description" content="Le jeu de balade urbaine où, guidé par des photos, vous partez à pied vers des lieux inconnus. Environ 15 min par partie, gratuit, sans achats intégrés." />
     <meta name="twitter:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+    <meta name="twitter:image:alt" content="Explores — le jeu de balade urbaine qui transforme la promenade en aventure" />
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
@@ -52,22 +60,19 @@
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
-        "@type": "MobileApplication",
-        "name": "Explores",
-        "description": "Le jeu de balade urbaine qui transforme la promenade en aventure. Guidé par des photos, partez à pied vers des lieux inconnus : une expérience d'exploration d'environ 15 minutes par partie.",
-        "url": "https://prokonjo.com/",
-        "applicationCategory": "GameApplication",
-        "operatingSystem": "iOS",
-        "offers": {
-          "@type": "Offer",
-          "price": "0",
-          "priceCurrency": "JPY"
-        },
-        "publisher": {
-          "@type": "Organization",
-          "name": "Prokonjo",
-          "url": "https://prokonjo.com/"
-        }
+        "@graph": [
+          { "@type": "Organization", "@id": "https://prokonjo.com/#org", "name": "Prokonjo", "url": "https://prokonjo.com/", "logo": "https://prokonjo.com/assets/img/game-logo.png", "sameAs": ["https://x.com/geek_pjt"] },
+          { "@type": "WebSite", "@id": "https://prokonjo.com/fr/#website", "url": "https://prokonjo.com/fr/", "name": "Explores", "inLanguage": "fr", "publisher": { "@id": "https://prokonjo.com/#org" } },
+          { "@type": "MobileApplication", "@id": "https://prokonjo.com/fr/#app", "name": "Explores", "description": "Explores, le jeu de balade urbaine qui transforme la promenade en aventure. Jeu de marche en géolocalisation (GPS), gratuit, sans achats intégrés.", "url": "https://prokonjo.com/fr/", "inLanguage": "fr", "applicationCategory": "GameApplication", "operatingSystem": "iOS", "installUrl": "https://apps.apple.com/app/id6477759574", "downloadUrl": "https://apps.apple.com/app/id6477759574", "screenshot": ["https://prokonjo.com/assets/img/game-play0.png","https://prokonjo.com/assets/img/game-play1.png","https://prokonjo.com/assets/img/game-play2.png"], "award": ["技育博 企業賞","和歌山イノベーションプログラミングコンテスト 最優秀賞","e-ZUKAスマートアプリコンテスト2023 飯塚市長賞・企業賞"], "offers": { "@type": "Offer", "price": "0", "priceCurrency": "JPY" }, "author": { "@id": "https://prokonjo.com/#org" }, "publisher": { "@id": "https://prokonjo.com/#org" } },
+          { "@type": "FAQPage", "@id": "https://prokonjo.com/fr/#faq", "inLanguage": "fr", "mainEntity": [
+            { "@type": "Question", "name": "C'est vraiment gratuit ? Y a-t-il des achats intégrés ?", "acceptedAnswer": { "@type": "Answer", "text": "C'est entièrement gratuit. Pas de gacha, pas d'abonnement, aucun achat intégré d'aucune sorte. Et pour l'instant, aucune publicité non plus." } },
+            { "@type": "Question", "name": "Combien de temps dure une partie ?", "acceptedAnswer": { "@type": "Answer", "text": "Vous choisissez parmi 15, 20 ou 30 minutes, selon votre humeur du moment. Que vous ayez un court créneau libre ou envie de bien marcher le week-end, les deux fonctionnent." } },
+            { "@type": "Question", "name": "Où peut-on jouer ?", "acceptedAnswer": { "@type": "Answer", "text": "En ville, vous pouvez en profiter à peu près partout. À partir de votre position GPS, une destination accessible à pied depuis votre point de départ est générée automatiquement." } },
+            { "@type": "Question", "name": "Quelle est la consommation de données et de batterie ?", "acceptedAnswer": { "@type": "Answer", "text": "Comme la localisation est captée en continu, la batterie se vide plus vite lors des parties longues. La consommation de données concerne surtout l'affichage de la carte et reste raisonnable." } },
+            { "@type": "Question", "name": "Quelles précautions pour jouer en toute sécurité ?", "acceptedAnswer": { "@type": "Answer", "text": "Soyez extrêmement prudent : ne manipulez pas votre téléphone en marchant. Arrêtez-vous avant les passages piétons, évitez les rues sombres et les zones désertes : respectez toujours les règles de base de sécurité d'une promenade." } },
+            { "@type": "Question", "name": "Existe-t-il une version Android ?", "acceptedAnswer": { "@type": "Answer", "text": "Nous reconfigurons actuellement notre publication Android ; le recrutement de testeurs est donc suspendu pour le moment. Nous publierons une mise à jour sur cette page dès que possible." } }
+          ] }
+        ]
       }
     </script>
 
@@ -144,7 +149,7 @@
           </p>
         </div>
         <div class="hero__visual">
-          <img src="/assets/img/game-desc.jpg" alt="Aperçu d'une partie d'Explores" width="1555" height="556" fetchpriority="high" />
+          <img src="/assets/img/game-desc.jpg" alt="Explores — aperçu d'une partie du jeu de balade urbaine en géolocalisation (GPS)" width="1555" height="556" fetchpriority="high" />
         </div>
       </div>
     </section>
@@ -207,19 +212,19 @@
         <div class="steps">
           <div class="step">
             <div class="step__num">1</div>
-            <img class="step__img" src="/assets/img/game-play0.png" alt="Écran de sélection de la durée" loading="lazy" />
+            <img class="step__img" src="/assets/img/game-play0.png" alt="Explores — écran de sélection de la durée de la balade urbaine" loading="lazy" />
             <h3>Choisissez votre durée</h3>
             <p>Sélectionnez le temps que vous voulez marcher. « 15 min », « 30 min »… selon votre humeur du moment.</p>
           </div>
           <div class="step">
             <div class="step__num">2</div>
-            <img class="step__img" src="/assets/img/game-play1.png" alt="Écran de vérification des photos et de la carte des environs de la destination" loading="lazy" />
+            <img class="step__img" src="/assets/img/game-play1.png" alt="Explores — écran des photos et de la carte des environs de la destination, jeu de marche en géolocalisation" loading="lazy" />
             <h3>Mémorisez la destination</h3>
             <p>Avant le départ, observez bien les photos et la carte des environs de la destination. Une fois la partie lancée, tout disparaît.</p>
           </div>
           <div class="step">
             <div class="step__num">3</div>
-            <img class="step__img" src="/assets/img/game-play2.png" alt="Écran de jeu pendant l'exploration" loading="lazy" />
+            <img class="step__img" src="/assets/img/game-play2.png" alt="Explores — écran de jeu pendant l'exploration à pied (GPS)" loading="lazy" />
             <h3>Marchez de mémoire</h3>
             <p>Avec pour seuls repères le temps restant et la distance, rejoignez la destination à pied. « Ça y est, c'est le paysage de la photo ! »</p>
           </div>

--- a/fr/tester-android/index.html
+++ b/fr/tester-android/index.html
@@ -8,6 +8,22 @@
     <meta name="theme-color" content="#FACD00" />
     <meta name="robots" content="noindex" />
     <link rel="canonical" href="https://prokonjo.com/fr/tester-android/" />
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Explores" />
+    <meta property="og:title" content="Recrutement de testeurs Android (en préparation)｜Explores" />
+    <meta property="og:description" content="Devenez testeur de la version Android d'Explores, le jeu de balade urbaine. Le recrutement est en préparation : laissez-vous guider en trois étapes." />
+    <meta property="og:url" content="https://prokonjo.com/fr/tester-android/" />
+    <meta property="og:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+    <meta property="og:locale" content="fr_FR" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Recrutement de testeurs Android (en préparation)｜Explores" />
+    <meta name="twitter:description" content="Devenez testeur de la version Android d'Explores, le jeu de balade urbaine. Le recrutement est en préparation : laissez-vous guider en trois étapes." />
+    <meta name="twitter:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -64,7 +80,7 @@
 
     <section class="page-header">
       <div class="container">
-        <h1>Testeurs Android (bientôt)</h1>
+        <h1>Recrutement de testeurs Android pour Explores (bientôt)</h1>
         <p class="page-header__lead">En vue de la sortie sur Google Play, nous recherchons des personnes prêtes à jouer en avant-première à Explores sur Android. Trois étapes suffisent pour participer !</p>
       </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-    <title>エクスプロラーズ｜散歩を冒険にする街歩きゲーム</title>
-    <meta name="description" content="散歩を冒険にする街歩きゲーム「エクスプロラーズ」。写真をヒントに、知らない場所を歩いて目指そう。1プレイ約15分・無料・課金要素なし。" />
+    <title>エクスプローラーズ｜散歩を冒険にする街歩きゲーム</title>
+    <meta name="description" content="散歩を冒険にする街歩きゲーム「エクスプローラーズ」。位置情報ゲーム／散歩アプリとして、写真をヒントに知らない場所を歩いて目指そう。1プレイ約15分・無料・課金要素なし。" />
     <meta name="author" content="プロ根性 (prokonjo)" />
     <meta name="theme-color" content="#FACD00" />
     <link rel="canonical" href="https://prokonjo.com/" />
@@ -21,21 +21,29 @@
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="エクスプロラーズ" />
-    <meta property="og:title" content="エクスプロラーズ｜散歩を冒険にする街歩きゲーム" />
+    <meta property="og:site_name" content="エクスプローラーズ" />
+    <meta property="og:title" content="エクスプローラーズ｜散歩を冒険にする街歩きゲーム" />
     <meta property="og:description" content="写真をヒントに、知らない場所を歩いて目指す街歩きゲーム。1プレイ約15分・無料・課金要素なし。" />
     <meta property="og:url" content="https://prokonjo.com/" />
     <meta property="og:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
     <meta property="og:image:type" content="image/jpeg" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="エクスプローラーズ — 散歩を冒険にする街歩きゲーム" />
     <meta property="og:locale" content="ja_JP" />
+    <meta property="og:locale:alternate" content="en_US" />
+    <meta property="og:locale:alternate" content="zh_TW" />
+    <meta property="og:locale:alternate" content="fr_FR" />
+    <meta property="og:locale:alternate" content="it_IT" />
+    <meta property="og:locale:alternate" content="es_ES" />
+    <meta property="og:locale:alternate" content="th_TH" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="エクスプロラーズ｜散歩を冒険にする街歩きゲーム" />
+    <meta name="twitter:title" content="エクスプローラーズ｜散歩を冒険にする街歩きゲーム" />
     <meta name="twitter:description" content="写真をヒントに、知らない場所を歩いて目指す街歩きゲーム。1プレイ約15分・無料・課金要素なし。" />
     <meta name="twitter:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+    <meta name="twitter:image:alt" content="エクスプローラーズ — 散歩を冒険にする街歩きゲーム" />
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
@@ -50,25 +58,22 @@
 
     <!-- Structured data -->
     <script type="application/ld+json">
-      {
-        "@context": "https://schema.org",
-        "@type": "MobileApplication",
-        "name": "エクスプロラーズ",
-        "description": "散歩を冒険にする街歩きゲーム。写真をヒントに知らない場所へ歩いて目指す、1プレイ約15分の探索体験。",
-        "url": "https://prokonjo.com/",
-        "applicationCategory": "GameApplication",
-        "operatingSystem": "iOS",
-        "offers": {
-          "@type": "Offer",
-          "price": "0",
-          "priceCurrency": "JPY"
-        },
-        "publisher": {
-          "@type": "Organization",
-          "name": "プロ根性",
-          "url": "https://prokonjo.com/"
-        }
-      }
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    { "@type": "Organization", "@id": "https://prokonjo.com/#org", "name": "プロ根性", "url": "https://prokonjo.com/", "logo": "https://prokonjo.com/assets/img/game-logo.png", "sameAs": ["https://x.com/geek_pjt"] },
+    { "@type": "WebSite", "@id": "https://prokonjo.com/#website", "url": "https://prokonjo.com/", "name": "エクスプローラーズ", "inLanguage": "ja", "publisher": { "@id": "https://prokonjo.com/#org" } },
+    { "@type": "MobileApplication", "@id": "https://prokonjo.com/#app", "name": "エクスプローラーズ", "alternateName": "エクスプロラーズ", "description": "散歩を冒険にする街歩きゲーム「エクスプローラーズ」。位置情報ゲーム／散歩アプリとして、写真をヒントに知らない場所を歩いて目指そう。1プレイ約15分・無料・課金要素なし。", "url": "https://prokonjo.com/", "inLanguage": "ja", "applicationCategory": "GameApplication", "operatingSystem": "iOS", "installUrl": "https://apps.apple.com/app/id6477759574", "downloadUrl": "https://apps.apple.com/app/id6477759574", "screenshot": ["https://prokonjo.com/assets/img/game-play0.png","https://prokonjo.com/assets/img/game-play1.png","https://prokonjo.com/assets/img/game-play2.png"], "award": ["技育博 企業賞","和歌山イノベーションプログラミングコンテスト 最優秀賞","e-ZUKAスマートアプリコンテスト2023 飯塚市長賞・企業賞"], "offers": { "@type": "Offer", "price": "0", "priceCurrency": "JPY" }, "author": { "@id": "https://prokonjo.com/#org" }, "publisher": { "@id": "https://prokonjo.com/#org" } },
+    { "@type": "FAQPage", "@id": "https://prokonjo.com/#faq", "inLanguage": "ja", "mainEntity": [
+      { "@type": "Question", "name": "本当に無料？課金要素はありますか？", "acceptedAnswer": { "@type": "Answer", "text": "完全無料です。ガチャやサブスクなど、いかなる課金要素もありません。広告も今のところ表示していません。" } },
+      { "@type": "Question", "name": "1プレイにかかる時間は？", "acceptedAnswer": { "@type": "Answer", "text": "15分・20分・30分などの中から、その時の気分に合わせて選べます。短い空き時間でもガッツリ歩きたい休日でも、両方行けます。" } },
+      { "@type": "Question", "name": "どんな場所で遊べますか？", "acceptedAnswer": { "@type": "Answer", "text": "街中であれば基本どこでも楽しめます。GPS情報を元に、現在地から歩いて辿り着ける範囲のゴールが自動生成されます。" } },
+      { "@type": "Question", "name": "通信量・バッテリー消費はどのくらい？", "acceptedAnswer": { "@type": "Answer", "text": "位置情報を継続的に取得するので、長時間プレイするとバッテリーは消費しやすくなります。通信量は地図表示分が中心で、過大ではありません。" } },
+      { "@type": "Question", "name": "安全に遊ぶための注意点は？", "acceptedAnswer": { "@type": "Answer", "text": "歩きながらの操作にはくれぐれもご注意ください。横断歩道の手前では立ち止まる、夜道や人気のないエリアは避ける、など基本的な散歩の安全ルールを必ず守ってください。" } },
+      { "@type": "Question", "name": "Android 版はありますか？", "acceptedAnswer": { "@type": "Answer", "text": "現在、Android版は配信の準備を整え直しているところで、テスター募集を一時停止しています。準備が整い次第、こちらのページでご案内します。" } }
+    ] }
+  ]
+}
     </script>
 
     <!-- Google Analytics -->
@@ -84,9 +89,9 @@
     <!-- ==================== Header ==================== -->
     <header class="site-header">
       <div class="container site-header__inner">
-        <a class="site-header__brand" href="#top" aria-label="エクスプロラーズ ホーム">
+        <a class="site-header__brand" href="#top" aria-label="エクスプローラーズ ホーム">
           <span class="site-header__brand-mark" aria-hidden="true">🧭</span>
-          <span>エクスプロラーズ</span>
+          <span>エクスプローラーズ</span>
         </a>
         <nav class="site-nav" aria-label="メインメニュー">
           <a href="#about">特徴</a>
@@ -130,7 +135,7 @@
           <h1 class="hero__title">散歩を、<em>冒険</em>にする。</h1>
           <p class="hero__sub">
             写真をヒントに、知らない場所を歩いて目指そう。<br />
-            1プレイ約15分。無料・課金要素なしの街歩きゲームです。
+            位置情報（GPS）を使った散歩アプリ。1プレイ約15分、無料・課金要素なしの街歩きゲームです。
           </p>
           <div class="hero__cta">
             <a class="app-badge" href="https://apps.apple.com/jp/app/%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA/id6477759574" aria-label="App Store からダウンロード">
@@ -144,7 +149,7 @@
           </p>
         </div>
         <div class="hero__visual">
-          <img src="/assets/img/game-desc.jpg" alt="エクスプロラーズのプレイイメージ" width="1555" height="556" fetchpriority="high" />
+          <img src="/assets/img/game-desc.jpg" alt="エクスプローラーズのプレイイメージ｜位置情報を使った街歩きゲーム" width="1555" height="556" fetchpriority="high" />
         </div>
       </div>
     </section>
@@ -177,7 +182,7 @@
     <!-- ==================== Value ==================== -->
     <section class="section">
       <div class="container">
-        <h2 class="section__title">エクスプロラーズなら、<br />散歩が冒険になる。</h2>
+        <h2 class="section__title">エクスプローラーズなら、<br />散歩が冒険になる。</h2>
         <p class="section__lead">写真というヒントだけで、知らない場所を目指す。<br />毎回違うゴール。15分で完結。「歩く理由」が、ここにある。</p>
         <div class="card-grid">
           <div class="value-card">
@@ -207,19 +212,19 @@
         <div class="steps">
           <div class="step">
             <div class="step__num">1</div>
-            <img class="step__img" src="/assets/img/game-play0.png" alt="時間選択画面" loading="lazy" />
+            <img class="step__img" src="/assets/img/game-play0.png" alt="時間選択画面｜位置情報を使った街歩きゲーム エクスプローラーズ" loading="lazy" />
             <h3>時間を選ぶ</h3>
             <p>歩きたい時間を選択。「15分」「30分」など、その時の気分に合わせて。</p>
           </div>
           <div class="step">
             <div class="step__num">2</div>
-            <img class="step__img" src="/assets/img/game-play1.png" alt="目的地周辺の写真と地図の確認画面" loading="lazy" />
+            <img class="step__img" src="/assets/img/game-play1.png" alt="目的地周辺の写真と地図の確認画面｜散歩アプリ エクスプローラーズ" loading="lazy" />
             <h3>目的地を覚える</h3>
             <p>目的地周辺の写真と地図を、ゲーム開始前にしっかり確認。スタートしたら隠れます。</p>
           </div>
           <div class="step">
             <div class="step__num">3</div>
-            <img class="step__img" src="/assets/img/game-play2.png" alt="探索中のゲーム画面" loading="lazy" />
+            <img class="step__img" src="/assets/img/game-play2.png" alt="探索中のゲーム画面｜位置情報を使った街歩きゲーム エクスプローラーズ" loading="lazy" />
             <h3>記憶を頼りに歩く</h3>
             <p>残り時間と距離だけを頼りに、目的地まで歩こう。「あっ、あの写真の景色だ！」</p>
           </div>
@@ -230,10 +235,10 @@
     <!-- ==================== Video ==================== -->
     <section class="section">
       <div class="container">
-        <h2 class="section__title">動画で見るエクスプロラーズ</h2>
+        <h2 class="section__title">動画で見るエクスプローラーズ</h2>
         <p class="section__lead">実際のプレイ画面と街歩きの様子をどうぞ。</p>
         <div class="video-wrap">
-          <iframe src="https://www.youtube.com/embed/ldIJdk3zwHY?si=jwntDJV8pnRAHKio" title="エクスプロラーズの遊び方紹介動画" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+          <iframe src="https://www.youtube.com/embed/ldIJdk3zwHY?si=jwntDJV8pnRAHKio" title="エクスプローラーズの遊び方紹介動画" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
         </div>
       </div>
     </section>
@@ -249,7 +254,7 @@
             <div class="award__body">
               <span class="award__tag">企業賞</span>
               <h3>技育博</h3>
-              <p>サポーターズ主催の技育博において、エクスプロラーズが企業賞を受賞しました。</p>
+              <p>サポーターズ主催の技育博において、エクスプローラーズが企業賞を受賞しました。</p>
               <a class="award__link" href="https://x.com/geek_pjt/status/1789225529109057540" target="_blank" rel="noopener noreferrer">受賞ポストを見る →</a>
             </div>
           </article>
@@ -373,7 +378,7 @@
         <p class="section__lead">不具合報告、ご感想、コラボのご相談など、お気軽にどうぞ。</p>
         <div class="contact-card">
           <p>以下のボタンからメールでご連絡ください。</p>
-          <a class="btn btn--lg" href="mailto:akmatsutaiki@gmail.com?subject=%E3%80%90%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%A9%E3%83%BC%E3%82%BA%E3%80%91%E3%81%8A%E5%95%8F%E3%81%84%E5%90%88%E3%82%8F%E3%81%9B">
+          <a class="btn btn--lg" href="mailto:akmatsutaiki@gmail.com?subject=%E3%80%90%E3%82%A8%E3%82%AF%E3%82%B9%E3%83%97%E3%83%AD%E3%83%BC%E3%83%A9%E3%83%BC%E3%82%BA%E3%80%91%E3%81%8A%E5%95%8F%E3%81%84%E5%90%88%E3%82%8F%E3%81%9B">
             メールで問い合わせる
           </a>
         </div>
@@ -385,8 +390,8 @@
       <div class="container">
         <div class="site-footer__grid">
           <div>
-            <div class="site-footer__brand">エクスプロラーズ</div>
-            <p class="site-footer__brand-line">散歩を冒険にする街歩きゲーム。<br />by プロ根性 (prokonjo)</p>
+            <div class="site-footer__brand">エクスプローラーズ</div>
+            <p class="site-footer__brand-line">散歩を冒険にする街歩きゲーム「エクスプローラーズ（エクスプロラーズ）」。<br />by プロ根性 (prokonjo)</p>
           </div>
           <div class="site-footer__col">
             <h4>サイト</h4>

--- a/it/index.html
+++ b/it/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <title>Explores｜Il gioco di passeggiate urbane che trasforma la camminata in avventura</title>
-    <meta name="description" content="Explores, il gioco di passeggiate urbane che trasforma la tua camminata in un'avventura. Seguendo le foto come indizio, raggiungi a piedi luoghi che non conosci. Una partita dura circa 15 minuti, gratis e senza acquisti in-app." />
+    <meta name="description" content="Explores, il gioco di camminata in geolocalizzazione (GPS) che trasforma le passeggiate in avventura. Gratis, senza acquisti in-app, una partita in 15 minuti." />
     <meta name="author" content="Prokonjo" />
     <meta name="theme-color" content="#FACD00" />
     <link rel="canonical" href="https://prokonjo.com/it/" />
@@ -29,13 +29,21 @@
     <meta property="og:image:type" content="image/jpeg" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Explores — il gioco di camminata in geolocalizzazione che trasforma le passeggiate in avventura" />
     <meta property="og:locale" content="it_IT" />
+    <meta property="og:locale:alternate" content="ja_JP" />
+    <meta property="og:locale:alternate" content="en_US" />
+    <meta property="og:locale:alternate" content="zh_TW" />
+    <meta property="og:locale:alternate" content="fr_FR" />
+    <meta property="og:locale:alternate" content="es_ES" />
+    <meta property="og:locale:alternate" content="th_TH" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Explores｜Il gioco di passeggiate urbane che trasforma la camminata in avventura" />
     <meta name="twitter:description" content="Il gioco di passeggiate urbane in cui, seguendo le foto come indizio, raggiungi a piedi luoghi che non conosci. Una partita dura circa 15 minuti, gratis e senza acquisti in-app." />
     <meta name="twitter:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+    <meta name="twitter:image:alt" content="Explores — il gioco di camminata in geolocalizzazione che trasforma le passeggiate in avventura" />
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
@@ -52,22 +60,19 @@
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
-        "@type": "MobileApplication",
-        "name": "Explores",
-        "description": "Il gioco di passeggiate urbane che trasforma la camminata in avventura. Seguendo le foto come indizio, raggiungi a piedi luoghi che non conosci: un'esperienza di esplorazione di circa 15 minuti a partita.",
-        "url": "https://prokonjo.com/",
-        "applicationCategory": "GameApplication",
-        "operatingSystem": "iOS",
-        "offers": {
-          "@type": "Offer",
-          "price": "0",
-          "priceCurrency": "JPY"
-        },
-        "publisher": {
-          "@type": "Organization",
-          "name": "Prokonjo",
-          "url": "https://prokonjo.com/"
-        }
+        "@graph": [
+          { "@type": "Organization", "@id": "https://prokonjo.com/#org", "name": "Prokonjo", "url": "https://prokonjo.com/", "logo": "https://prokonjo.com/assets/img/game-logo.png", "sameAs": ["https://x.com/geek_pjt"] },
+          { "@type": "WebSite", "@id": "https://prokonjo.com/it/#website", "url": "https://prokonjo.com/it/", "name": "Explores", "inLanguage": "it", "publisher": { "@id": "https://prokonjo.com/#org" } },
+          { "@type": "MobileApplication", "@id": "https://prokonjo.com/it/#app", "name": "Explores", "description": "Explores, il gioco di camminata in geolocalizzazione (GPS) che trasforma le passeggiate in avventura. Gratis, senza acquisti in-app, una partita in 15 minuti.", "url": "https://prokonjo.com/it/", "inLanguage": "it", "applicationCategory": "GameApplication", "operatingSystem": "iOS", "installUrl": "https://apps.apple.com/app/id6477759574", "downloadUrl": "https://apps.apple.com/app/id6477759574", "screenshot": ["https://prokonjo.com/assets/img/game-play0.png","https://prokonjo.com/assets/img/game-play1.png","https://prokonjo.com/assets/img/game-play2.png"], "award": ["技育博 企業賞","和歌山イノベーションプログラミングコンテスト 最優秀賞","e-ZUKAスマートアプリコンテスト2023 飯塚市長賞・企業賞"], "offers": { "@type": "Offer", "price": "0", "priceCurrency": "JPY" }, "author": { "@id": "https://prokonjo.com/#org" }, "publisher": { "@id": "https://prokonjo.com/#org" } },
+          { "@type": "FAQPage", "@id": "https://prokonjo.com/it/#faq", "inLanguage": "it", "mainEntity": [
+            { "@type": "Question", "name": "È davvero gratis? Ci sono acquisti in-app?", "acceptedAnswer": { "@type": "Answer", "text": "È completamente gratuito. Niente gacha, niente abbonamenti, nessun tipo di acquisto in-app. E per ora non mostriamo nemmeno pubblicità." } },
+            { "@type": "Question", "name": "Quanto dura una partita?", "acceptedAnswer": { "@type": "Answer", "text": "Puoi scegliere tra 15, 20 o 30 minuti, a seconda dell'umore del momento. Va bene sia per una breve pausa sia per una camminata intensa nel weekend." } },
+            { "@type": "Question", "name": "Dove si può giocare?", "acceptedAnswer": { "@type": "Answer", "text": "In linea di massima si gioca ovunque in città. In base al GPS, viene generata automaticamente una meta raggiungibile a piedi dalla tua posizione attuale." } },
+            { "@type": "Question", "name": "Quanti dati e quanta batteria consuma?", "acceptedAnswer": { "@type": "Answer", "text": "Poiché la posizione viene rilevata di continuo, le sessioni lunghe tendono a consumare più batteria. Il consumo di dati riguarda soprattutto la visualizzazione della mappa e non è eccessivo." } },
+            { "@type": "Question", "name": "Come giocare in sicurezza?", "acceptedAnswer": { "@type": "Answer", "text": "Fai sempre molta attenzione a non usare il telefono mentre cammini. Fermati prima degli attraversamenti pedonali, evita le strade buie e le zone poco frequentate, e rispetta sempre le regole di base per camminare in sicurezza." } },
+            { "@type": "Question", "name": "Esiste la versione Android?", "acceptedAnswer": { "@type": "Answer", "text": "Al momento stiamo riconfigurando la pubblicazione su Android, quindi il reclutamento dei tester è sospeso. Pubblicheremo un aggiornamento su questa pagina appena sarà pronto." } }
+          ] }
+        ]
       }
     </script>
 
@@ -144,7 +149,7 @@
           </p>
         </div>
         <div class="hero__visual">
-          <img src="/assets/img/game-desc.jpg" alt="Immagine di gioco di Explores" width="1555" height="556" fetchpriority="high" />
+          <img src="/assets/img/game-desc.jpg" alt="Explores — gioco di camminata in geolocalizzazione (GPS) per esplorare la città a piedi" width="1555" height="556" fetchpriority="high" />
         </div>
       </div>
     </section>
@@ -207,19 +212,19 @@
         <div class="steps">
           <div class="step">
             <div class="step__num">1</div>
-            <img class="step__img" src="/assets/img/game-play0.png" alt="Schermata di selezione del tempo" loading="lazy" />
+            <img class="step__img" src="/assets/img/game-play0.png" alt="Explores — schermata di selezione del tempo nel gioco di camminata in geolocalizzazione" loading="lazy" />
             <h3>Scegli il tempo</h3>
             <p>Seleziona quanto vuoi camminare. "15 minuti", "30 minuti"... a seconda dell'umore del momento.</p>
           </div>
           <div class="step">
             <div class="step__num">2</div>
-            <img class="step__img" src="/assets/img/game-play1.png" alt="Schermata di verifica delle foto e della mappa dei dintorni della meta" loading="lazy" />
+            <img class="step__img" src="/assets/img/game-play1.png" alt="Explores — foto e mappa dei dintorni della meta nel gioco di passeggiate urbane" loading="lazy" />
             <h3>Memorizza la meta</h3>
             <p>Prima di iniziare, osserva bene le foto e la mappa dei dintorni della meta. Una volta partito, spariscono.</p>
           </div>
           <div class="step">
             <div class="step__num">3</div>
-            <img class="step__img" src="/assets/img/game-play2.png" alt="Schermata di gioco durante l'esplorazione" loading="lazy" />
+            <img class="step__img" src="/assets/img/game-play2.png" alt="Explores — schermata di gioco mentre cammini verso la meta a piedi" loading="lazy" />
             <h3>Cammina affidandoti alla memoria</h3>
             <p>Con solo il tempo rimasto e la distanza come riferimento, raggiungi la meta a piedi. "Ehi, è proprio il paesaggio di quella foto!"</p>
           </div>
@@ -295,17 +300,17 @@
             </div>
           </div>
           <div class="member">
-            <img src="/assets/img/member-chang.png" alt="張珠煐" loading="lazy" width="96" height="96" />
+            <img src="/assets/img/member-chang.png" alt="Chang Ju-young" loading="lazy" width="96" height="96" />
             <h3>張珠煐</h3>
             <p>Designer</p>
           </div>
           <div class="member">
-            <img src="/assets/img/siteTop4.jpg" alt="楠本健人" loading="lazy" width="96" height="96" />
+            <img src="/assets/img/siteTop4.jpg" alt="Kento Kusumoto" loading="lazy" width="96" height="96" />
             <h3>楠本健人</h3>
             <p>Designer</p>
           </div>
           <div class="member">
-            <img src="/assets/img/member-hayashi.png" alt="林慎一郎" loading="lazy" width="96" height="96" />
+            <img src="/assets/img/member-hayashi.png" alt="Shinichiro Hayashi" loading="lazy" width="96" height="96" />
             <h3>林慎一郎</h3>
             <p>Ingegnere</p>
             <div class="member__links">

--- a/it/tester-android/index.html
+++ b/it/tester-android/index.html
@@ -8,6 +8,22 @@
     <meta name="theme-color" content="#FACD00" />
     <meta name="robots" content="noindex" />
     <link rel="canonical" href="https://prokonjo.com/it/tester-android/" />
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Explores" />
+    <meta property="og:title" content="Cerchiamo tester Android (in arrivo)｜Explores" />
+    <meta property="og:description" content="Cerchiamo persone che vogliano provare Explores in anteprima su Android. La pubblicazione è in preparazione: bastano 3 passaggi per partecipare." />
+    <meta property="og:url" content="https://prokonjo.com/it/tester-android/" />
+    <meta property="og:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+    <meta property="og:locale" content="it_IT" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Cerchiamo tester Android (in arrivo)｜Explores" />
+    <meta name="twitter:description" content="Cerchiamo persone che vogliano provare Explores in anteprima su Android. La pubblicazione è in preparazione: bastano 3 passaggi per partecipare." />
+    <meta name="twitter:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -64,7 +80,7 @@
 
     <section class="page-header">
       <div class="container">
-        <h1>Tester Android (in arrivo)</h1>
+        <h1>Explores — Cerchiamo tester Android (in arrivo)</h1>
         <p class="page-header__lead">In vista della pubblicazione su Google Play, cerchiamo persone che vogliano provare Explores in anteprima su Android. Bastano 3 passaggi per partecipare!</p>
       </div>
     </section>

--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-    <title>プライバシーポリシー｜エクスプロラーズ</title>
-    <meta name="description" content="エクスプロラーズのプライバシーポリシー。位置情報の取り扱いやデータ保持期間について。" />
+    <title>プライバシーポリシー｜エクスプローラーズ</title>
+    <meta name="description" content="エクスプローラーズのプライバシーポリシー。位置情報の取り扱いやデータ保持期間について。" />
     <meta name="theme-color" content="#FACD00" />
     <meta name="robots" content="noindex" />
     <link rel="canonical" href="https://prokonjo.com/privacy-policy/" />
@@ -24,9 +24,9 @@
   <body>
     <header class="site-header">
       <div class="container site-header__inner">
-        <a class="site-header__brand" href="/" aria-label="エクスプロラーズ ホーム">
+        <a class="site-header__brand" href="/" aria-label="エクスプローラーズ ホーム">
           <span class="site-header__brand-mark" aria-hidden="true">🧭</span>
-          <span>エクスプロラーズ</span>
+          <span>エクスプローラーズ</span>
         </a>
         <nav class="site-nav" aria-label="メインメニュー">
           <a href="/#about">特徴</a>
@@ -65,14 +65,14 @@
     <section class="page-header">
       <div class="container">
         <h1>プライバシーポリシー</h1>
-        <p class="page-header__lead">エクスプロラーズで取り扱う情報と利用目的について。</p>
+        <p class="page-header__lead">エクスプローラーズで取り扱う情報と利用目的について。</p>
       </div>
     </section>
 
     <section class="section">
       <div class="container">
         <article class="prose">
-          <p>本プライバシーポリシーは、Taiki Akamatsu（以下「サービス提供者」）が無料で提供するモバイル向けアプリケーション「エクスプロラーズ」（以下「本アプリ」）に適用されます。本サービスは「現状のまま」の利用を前提として提供されます。</p>
+          <p>本プライバシーポリシーは、Taiki Akamatsu（以下「サービス提供者」）が無料で提供するモバイル向けアプリケーション「エクスプローラーズ」（以下「本アプリ」）に適用されます。本サービスは「現状のまま」の利用を前提として提供されます。</p>
 
           <h2>収集する情報と利用目的</h2>
           <p>本アプリは、ダウンロードおよび利用時に以下のような情報を収集する場合があります。</p>
@@ -141,7 +141,7 @@
       <div class="container">
         <div class="site-footer__grid">
           <div>
-            <div class="site-footer__brand">エクスプロラーズ</div>
+            <div class="site-footer__brand">エクスプローラーズ</div>
             <p class="site-footer__brand-line">散歩を冒険にする街歩きゲーム。<br />by プロ根性 (prokonjo)</p>
           </div>
           <div class="site-footer__col">

--- a/tester-android/index.html
+++ b/tester-android/index.html
@@ -3,11 +3,27 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-    <title>Android テスター募集中｜エクスプロラーズ</title>
-    <meta name="description" content="エクスプロラーズの Android テスター募集ページ。Google Groups 登録 → アプリインストール → 起動の3ステップ。" />
+    <title>Android テスター募集（準備中）｜エクスプローラーズ</title>
+    <meta name="description" content="エクスプローラーズの Android テスター募集ページ（現在準備中）。Google Groups 登録 → アプリインストール → 起動の3ステップ。" />
     <meta name="theme-color" content="#FACD00" />
     <meta name="robots" content="noindex" />
     <link rel="canonical" href="https://prokonjo.com/tester-android/" />
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="エクスプローラーズ" />
+    <meta property="og:title" content="Android テスター募集（準備中）｜エクスプローラーズ" />
+    <meta property="og:description" content="エクスプローラーズの Android テスター募集ページ（現在準備中）。Google Groups 登録 → アプリインストール → 起動の3ステップ。" />
+    <meta property="og:url" content="https://prokonjo.com/tester-android/" />
+    <meta property="og:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+    <meta property="og:locale" content="ja_JP" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Android テスター募集（準備中）｜エクスプローラーズ" />
+    <meta name="twitter:description" content="エクスプローラーズの Android テスター募集ページ（現在準備中）。Google Groups 登録 → アプリインストール → 起動の3ステップ。" />
+    <meta name="twitter:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -24,9 +40,9 @@
   <body>
     <header class="site-header">
       <div class="container site-header__inner">
-        <a class="site-header__brand" href="/" aria-label="エクスプロラーズ ホーム">
+        <a class="site-header__brand" href="/" aria-label="エクスプローラーズ ホーム">
           <span class="site-header__brand-mark" aria-hidden="true">🧭</span>
-          <span>エクスプロラーズ</span>
+          <span>エクスプローラーズ</span>
         </a>
         <nav class="site-nav" aria-label="メインメニュー">
           <a href="/#about">特徴</a>
@@ -64,8 +80,8 @@
 
     <section class="page-header">
       <div class="container">
-        <h1>Android テスター（準備中）</h1>
-        <p class="page-header__lead">Google Play 公開に向けて、エクスプロラーズを Android で先行プレイしてくださる方を募集しています。3 ステップで参加完了！</p>
+        <h1>エクスプローラーズ Android テスター募集（準備中）</h1>
+        <p class="page-header__lead">Google Play 公開に向けて、エクスプローラーズを Android で先行プレイしてくださる方を募集しています。3 ステップで参加完了！</p>
       </div>
     </section>
 
@@ -144,7 +160,7 @@
       <div class="container">
         <div class="site-footer__grid">
           <div>
-            <div class="site-footer__brand">エクスプロラーズ</div>
+            <div class="site-footer__brand">エクスプローラーズ</div>
             <p class="site-footer__brand-line">散歩を冒険にする街歩きゲーム。<br />by プロ根性 (prokonjo)</p>
           </div>
           <div class="site-footer__col">

--- a/th/index.html
+++ b/th/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <title>Explores｜เกมเดินสำรวจเมืองที่เปลี่ยนการเดินเล่นให้เป็นการผจญภัย</title>
-    <meta name="description" content="Explores เกมเดินสำรวจเมืองที่เปลี่ยนการเดินเล่นธรรมดาให้กลายเป็นการผจญภัย ใช้รูปภาพเป็นใบ้แล้วเดินไปยังสถานที่ที่ไม่เคยรู้จัก เล่นรอบละราว 15 นาที ฟรี ไม่มีระบบเติมเงิน" />
+    <meta name="description" content="Explores เกมเดินสำรวจเมืองแบบใช้พิกัด GPS ที่เปลี่ยนการเดินเล่นธรรมดาให้กลายเป็นการผจญภัย ใช้รูปภาพเป็นใบ้แล้วเดินไปยังสถานที่ที่ไม่เคยรู้จัก เล่นรอบละราว 15 นาที ฟรี ไม่มีระบบเติมเงิน" />
     <meta name="author" content="Prokonjo" />
     <meta name="theme-color" content="#FACD00" />
     <link rel="canonical" href="https://prokonjo.com/th/" />
@@ -29,13 +29,21 @@
     <meta property="og:image:type" content="image/jpeg" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Explores — เกมเดินสำรวจเมืองแบบใช้พิกัด GPS เปลี่ยนการเดินเล่นให้เป็นการผจญภัย" />
     <meta property="og:locale" content="th_TH" />
+    <meta property="og:locale:alternate" content="ja_JP" />
+    <meta property="og:locale:alternate" content="en_US" />
+    <meta property="og:locale:alternate" content="zh_TW" />
+    <meta property="og:locale:alternate" content="fr_FR" />
+    <meta property="og:locale:alternate" content="it_IT" />
+    <meta property="og:locale:alternate" content="es_ES" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Explores｜เกมเดินสำรวจเมืองที่เปลี่ยนการเดินเล่นให้เป็นการผจญภัย" />
     <meta name="twitter:description" content="เกมเดินสำรวจเมืองที่ใช้รูปภาพเป็นใบ้ แล้วเดินไปยังสถานที่ที่ไม่เคยรู้จัก เล่นรอบละราว 15 นาที ฟรี ไม่มีระบบเติมเงิน" />
     <meta name="twitter:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+    <meta name="twitter:image:alt" content="Explores — เกมเดินสำรวจเมืองแบบใช้พิกัด GPS เปลี่ยนการเดินเล่นให้เป็นการผจญภัย" />
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
@@ -52,22 +60,19 @@
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
-        "@type": "MobileApplication",
-        "name": "Explores",
-        "description": "เกมเดินสำรวจเมืองที่เปลี่ยนการเดินเล่นให้เป็นการผจญภัย ใช้รูปภาพเป็นใบ้แล้วเดินไปยังสถานที่ที่ไม่เคยรู้จัก ประสบการณ์การสำรวจรอบละราว 15 นาที",
-        "url": "https://prokonjo.com/th/",
-        "applicationCategory": "GameApplication",
-        "operatingSystem": "iOS",
-        "offers": {
-          "@type": "Offer",
-          "price": "0",
-          "priceCurrency": "JPY"
-        },
-        "publisher": {
-          "@type": "Organization",
-          "name": "Prokonjo",
-          "url": "https://prokonjo.com/"
-        }
+        "@graph": [
+          { "@type": "Organization", "@id": "https://prokonjo.com/#org", "name": "Prokonjo", "url": "https://prokonjo.com/", "logo": "https://prokonjo.com/assets/img/game-logo.png", "sameAs": ["https://x.com/geek_pjt"] },
+          { "@type": "WebSite", "@id": "https://prokonjo.com/th/#website", "url": "https://prokonjo.com/th/", "name": "Explores", "inLanguage": "th", "publisher": { "@id": "https://prokonjo.com/#org" } },
+          { "@type": "MobileApplication", "@id": "https://prokonjo.com/th/#app", "name": "Explores", "description": "Explores เกมเดินสำรวจเมืองแบบใช้พิกัด GPS ที่เปลี่ยนการเดินเล่นธรรมดาให้กลายเป็นการผจญภัย ใช้รูปภาพเป็นใบ้แล้วเดินไปยังสถานที่ที่ไม่เคยรู้จัก เล่นรอบละราว 15 นาที ฟรี ไม่มีระบบเติมเงิน", "url": "https://prokonjo.com/th/", "inLanguage": "th", "applicationCategory": "GameApplication", "operatingSystem": "iOS", "installUrl": "https://apps.apple.com/app/id6477759574", "downloadUrl": "https://apps.apple.com/app/id6477759574", "screenshot": ["https://prokonjo.com/assets/img/game-play0.png","https://prokonjo.com/assets/img/game-play1.png","https://prokonjo.com/assets/img/game-play2.png"], "award": ["技育博 企業賞","和歌山イノベーションプログラミングコンテスト 最優秀賞","e-ZUKAスマートアプリコンテスト2023 飯塚市長賞・企業賞"], "offers": { "@type": "Offer", "price": "0", "priceCurrency": "JPY" }, "author": { "@id": "https://prokonjo.com/#org" }, "publisher": { "@id": "https://prokonjo.com/#org" } },
+          { "@type": "FAQPage", "@id": "https://prokonjo.com/th/#faq", "inLanguage": "th", "mainEntity": [
+            { "@type": "Question", "name": "ฟรีจริงไหม? มีระบบเติมเงินหรือเปล่า?", "acceptedAnswer": { "@type": "Answer", "text": "ฟรีทั้งหมด ไม่มีระบบเติมเงินใด ๆ ทั้งกาชาหรือสมาชิกรายเดือน และตอนนี้ก็ยังไม่มีโฆษณาแสดงด้วย" } },
+            { "@type": "Question", "name": "เล่นหนึ่งรอบใช้เวลานานแค่ไหน?", "acceptedAnswer": { "@type": "Answer", "text": "เลือกได้ตามอารมณ์ในตอนนั้น เช่น 15 นาที 20 นาที หรือ 30 นาที จะเป็นช่วงเวลาว่างสั้น ๆ หรือวันหยุดที่อยากเดินยาว ๆ ก็เล่นได้ทั้งคู่" } },
+            { "@type": "Question", "name": "เล่นได้ในสถานที่แบบไหนบ้าง?", "acceptedAnswer": { "@type": "Answer", "text": "โดยพื้นฐานสนุกได้ทุกที่ที่อยู่ในเมือง ระบบจะสร้างจุดหมายที่เดินไปถึงได้จากตำแหน่งปัจจุบันโดยอัตโนมัติ โดยอ้างอิงจากข้อมูล GPS" } },
+            { "@type": "Question", "name": "ใช้ปริมาณเน็ตและแบตเตอรี่มากแค่ไหน?", "acceptedAnswer": { "@type": "Answer", "text": "เนื่องจากต้องดึงข้อมูลตำแหน่งต่อเนื่อง การเล่นเป็นเวลานานจึงทำให้แบตเตอรี่หมดเร็วขึ้น ส่วนปริมาณเน็ตส่วนใหญ่ใช้กับการแสดงแผนที่ ซึ่งไม่ได้มากเกินไป" } },
+            { "@type": "Question", "name": "มีข้อควรระวังเพื่อเล่นอย่างปลอดภัยไหม?", "acceptedAnswer": { "@type": "Answer", "text": "โปรดระมัดระวังอย่างยิ่งในการกดจอขณะเดิน กรุณาปฏิบัติตามกฎความปลอดภัยพื้นฐานในการเดินเล่นเสมอ เช่น หยุดยืนก่อนถึงทางม้าลาย และหลีกเลี่ยงทางเปลี่ยวยามค่ำคืนหรือพื้นที่ที่ไม่มีคน" } },
+            { "@type": "Question", "name": "มีเวอร์ชัน Android ไหม?", "acceptedAnswer": { "@type": "Answer", "text": "ขณะนี้เรากำลังจัดเตรียมการเผยแพร่บน Android ใหม่ จึงหยุดรับสมัครผู้ทดสอบชั่วคราว เราจะแจ้งให้ทราบที่หน้านี้เมื่อพร้อม" } }
+          ] }
+        ]
       }
     </script>
 
@@ -144,7 +149,7 @@
           </p>
         </div>
         <div class="hero__visual">
-          <img src="/assets/img/game-desc.jpg" alt="ภาพตัวอย่างการเล่น Explores" width="1555" height="556" fetchpriority="high" />
+          <img src="/assets/img/game-desc.jpg" alt="Explores — ภาพตัวอย่างการเล่นเกมเดินสำรวจเมืองแบบใช้พิกัด GPS" width="1555" height="556" fetchpriority="high" />
         </div>
       </div>
     </section>
@@ -207,19 +212,19 @@
         <div class="steps">
           <div class="step">
             <div class="step__num">1</div>
-            <img class="step__img" src="/assets/img/game-play0.png" alt="หน้าจอเลือกเวลา" loading="lazy" />
+            <img class="step__img" src="/assets/img/game-play0.png" alt="Explores เกมเดินสำรวจเมือง — หน้าจอเลือกเวลา" loading="lazy" />
             <h3>เลือกเวลา</h3>
             <p>เลือกเวลาที่อยากเดิน เช่น "15 นาที" "30 นาที" ตามอารมณ์ในตอนนั้น</p>
           </div>
           <div class="step">
             <div class="step__num">2</div>
-            <img class="step__img" src="/assets/img/game-play1.png" alt="หน้าจอตรวจสอบรูปภาพและแผนที่บริเวณจุดหมาย" loading="lazy" />
+            <img class="step__img" src="/assets/img/game-play1.png" alt="Explores เกมเดินสำรวจเมือง — หน้าจอตรวจสอบรูปภาพและแผนที่บริเวณจุดหมาย" loading="lazy" />
             <h3>จดจำจุดหมายให้ดี</h3>
             <p>ดูรูปภาพและแผนที่บริเวณจุดหมายให้ละเอียดก่อนเริ่มเกม พอเริ่มแล้วทั้งหมดจะถูกซ่อนไป</p>
           </div>
           <div class="step">
             <div class="step__num">3</div>
-            <img class="step__img" src="/assets/img/game-play2.png" alt="หน้าจอเกมระหว่างการสำรวจ" loading="lazy" />
+            <img class="step__img" src="/assets/img/game-play2.png" alt="Explores เกมเดินสำรวจเมือง — หน้าจอเกมระหว่างการสำรวจ" loading="lazy" />
             <h3>เดินโดยอาศัยความทรงจำ</h3>
             <p>เดินไปยังจุดหมายโดยมีแค่เวลาที่เหลือและระยะทางเป็นตัวช่วย "อ๊ะ นี่มันวิวในรูปนั่นนี่!"</p>
           </div>

--- a/th/tester-android/index.html
+++ b/th/tester-android/index.html
@@ -8,6 +8,22 @@
     <meta name="theme-color" content="#FACD00" />
     <meta name="robots" content="noindex" />
     <link rel="canonical" href="https://prokonjo.com/th/tester-android/" />
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Explores" />
+    <meta property="og:title" content="รับสมัครผู้ทดสอบ Android ของ Explores (เร็ว ๆ นี้)" />
+    <meta property="og:description" content="เรากำลังเตรียมเปิดตัว Explores บน Android และมองหาผู้ทดสอบรุ่นแรก สมัครได้ใน 3 ขั้นตอน เปิดรับเร็ว ๆ นี้" />
+    <meta property="og:url" content="https://prokonjo.com/th/tester-android/" />
+    <meta property="og:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+    <meta property="og:locale" content="th_TH" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="รับสมัครผู้ทดสอบ Android ของ Explores (เร็ว ๆ นี้)" />
+    <meta name="twitter:description" content="เรากำลังเตรียมเปิดตัว Explores บน Android และมองหาผู้ทดสอบรุ่นแรก สมัครได้ใน 3 ขั้นตอน เปิดรับเร็ว ๆ นี้" />
+    <meta name="twitter:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -64,7 +80,7 @@
 
     <section class="page-header">
       <div class="container">
-        <h1>ผู้ทดสอบ Android (เร็ว ๆ นี้)</h1>
+        <h1>รับสมัครผู้ทดสอบ Android ของ Explores (เร็ว ๆ นี้)</h1>
         <p class="page-header__lead">เรากำลังมองหาผู้ที่จะมาเล่น Explores บน Android ก่อนใคร เพื่อเตรียมเปิดตัวบน Google Play สมัครเข้าร่วมได้เลยใน 3 ขั้นตอน!</p>
       </div>
     </section>

--- a/zh/index.html
+++ b/zh/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <title>Explores｜把散步變成冒險的街頭探索遊戲</title>
-    <meta name="description" content="把散步變成冒險的街頭探索遊戲「Explores」。以照片為提示，走進陌生的地方一步步抵達目的地。一局約 15 分鐘、免費、無內購。" />
+    <meta name="description" content="把散步變成冒險的定位（GPS）街頭探索遊戲「Explores」。以照片為提示，走進陌生的地方一步步抵達目的地。一局約 15 分鐘、免費、無內購。" />
     <meta name="author" content="Prokonjo" />
     <meta name="theme-color" content="#FACD00" />
     <link rel="canonical" href="https://prokonjo.com/zh/" />
@@ -29,13 +29,21 @@
     <meta property="og:image:type" content="image/jpeg" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
+    <meta property="og:image:alt" content="Explores — 把散步變成冒險的定位街頭探索遊戲" />
     <meta property="og:locale" content="zh_TW" />
+    <meta property="og:locale:alternate" content="ja_JP" />
+    <meta property="og:locale:alternate" content="en_US" />
+    <meta property="og:locale:alternate" content="fr_FR" />
+    <meta property="og:locale:alternate" content="it_IT" />
+    <meta property="og:locale:alternate" content="es_ES" />
+    <meta property="og:locale:alternate" content="th_TH" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Explores｜把散步變成冒險的街頭探索遊戲" />
     <meta name="twitter:description" content="以照片為提示，走進陌生的地方一步步抵達目的地的街頭探索遊戲。一局約 15 分鐘、免費、無內購。" />
     <meta name="twitter:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+    <meta name="twitter:image:alt" content="Explores — 把散步變成冒險的定位街頭探索遊戲" />
 
     <!-- Favicon -->
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
@@ -52,22 +60,19 @@
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
-        "@type": "MobileApplication",
-        "name": "Explores",
-        "description": "把散步變成冒險的街頭探索遊戲。以照片為提示，走進陌生的地方一步步抵達目的地，一局約 15 分鐘的探索體驗。",
-        "url": "https://prokonjo.com/",
-        "applicationCategory": "GameApplication",
-        "operatingSystem": "iOS",
-        "offers": {
-          "@type": "Offer",
-          "price": "0",
-          "priceCurrency": "JPY"
-        },
-        "publisher": {
-          "@type": "Organization",
-          "name": "Prokonjo",
-          "url": "https://prokonjo.com/"
-        }
+        "@graph": [
+          { "@type": "Organization", "@id": "https://prokonjo.com/#org", "name": "Prokonjo", "url": "https://prokonjo.com/", "logo": "https://prokonjo.com/assets/img/game-logo.png", "sameAs": ["https://x.com/geek_pjt"] },
+          { "@type": "WebSite", "@id": "https://prokonjo.com/zh/#website", "url": "https://prokonjo.com/zh/", "name": "Explores", "inLanguage": "zh-Hant", "publisher": { "@id": "https://prokonjo.com/#org" } },
+          { "@type": "MobileApplication", "@id": "https://prokonjo.com/zh/#app", "name": "Explores", "description": "把散步變成冒險的定位（GPS）街頭探索遊戲「Explores」。以照片為提示，走進陌生的地方一步步抵達目的地。一局約 15 分鐘、免費、無內購。", "url": "https://prokonjo.com/zh/", "inLanguage": "zh-Hant", "applicationCategory": "GameApplication", "operatingSystem": "iOS", "installUrl": "https://apps.apple.com/app/id6477759574", "downloadUrl": "https://apps.apple.com/app/id6477759574", "screenshot": ["https://prokonjo.com/assets/img/game-play0.png","https://prokonjo.com/assets/img/game-play1.png","https://prokonjo.com/assets/img/game-play2.png"], "award": ["技育博 企業賞","和歌山イノベーションプログラミングコンテスト 最優秀賞","e-ZUKAスマートアプリコンテスト2023 飯塚市長賞・企業賞"], "offers": { "@type": "Offer", "price": "0", "priceCurrency": "JPY" }, "author": { "@id": "https://prokonjo.com/#org" }, "publisher": { "@id": "https://prokonjo.com/#org" } },
+          { "@type": "FAQPage", "@id": "https://prokonjo.com/zh/#faq", "inLanguage": "zh-Hant", "mainEntity": [
+            { "@type": "Question", "name": "真的免費嗎？有任何內購嗎？", "acceptedAnswer": { "@type": "Answer", "text": "完全免費。沒有任何轉蛋、訂閱等內購項目。目前也不會顯示任何廣告。" } },
+            { "@type": "Question", "name": "玩一局要多久？", "acceptedAnswer": { "@type": "Answer", "text": "可從 15 分鐘、20 分鐘、30 分鐘等選項中，依當下心情自由選擇。無論是短暫的空檔，還是想盡情走的假日，都能對應。" } },
+            { "@type": "Question", "name": "在什麼地方可以玩？", "acceptedAnswer": { "@type": "Answer", "text": "只要在街區內，基本上到哪都能玩。系統會依 GPS 資訊，自動生成從你目前位置走得到的目的地範圍。" } },
+            { "@type": "Question", "name": "數據用量與電池消耗大概多少？", "acceptedAnswer": { "@type": "Answer", "text": "由於會持續取得定位資訊，長時間遊玩時電池確實比較容易耗電。數據用量主要來自地圖顯示，並不會太龐大。" } },
+            { "@type": "Question", "name": "安全遊玩有哪些注意事項？", "acceptedAnswer": { "@type": "Answer", "text": "請務必避免邊走邊操作手機。過斑馬線前先停下腳步、避開夜路與人煙稀少的區域等等，散步時的基本安全守則請一定要遵守。" } },
+            { "@type": "Question", "name": "有 Android 版嗎？", "acceptedAnswer": { "@type": "Answer", "text": "目前正在重新整理 Android 的發佈環境，暫停招募測試者。準備就緒後將於這個頁面公布。" } }
+          ] }
+        ]
       }
     </script>
 
@@ -144,7 +149,7 @@
           </p>
         </div>
         <div class="hero__visual">
-          <img src="/assets/img/game-desc.jpg" alt="Explores 的遊玩示意圖" width="1555" height="556" fetchpriority="high" />
+          <img src="/assets/img/game-desc.jpg" alt="Explores 的遊玩示意圖｜定位（GPS）街頭探索遊戲" width="1555" height="556" fetchpriority="high" />
         </div>
       </div>
     </section>
@@ -207,19 +212,19 @@
         <div class="steps">
           <div class="step">
             <div class="step__num">1</div>
-            <img class="step__img" src="/assets/img/game-play0.png" alt="時間選擇畫面" loading="lazy" />
+            <img class="step__img" src="/assets/img/game-play0.png" alt="Explores 的時間選擇畫面｜街頭探索遊戲" loading="lazy" />
             <h3>選擇時間</h3>
             <p>選一段想走的時間，「15 分鐘」「30 分鐘」⋯⋯依當下的心情自由決定。</p>
           </div>
           <div class="step">
             <div class="step__num">2</div>
-            <img class="step__img" src="/assets/img/game-play1.png" alt="確認目的地周邊照片與地圖的畫面" loading="lazy" />
+            <img class="step__img" src="/assets/img/game-play1.png" alt="Explores 確認目的地周邊照片與地圖的畫面｜街頭探索遊戲" loading="lazy" />
             <h3>記住目的地</h3>
             <p>遊戲開始前，先把目的地周邊的照片與地圖看仔細。一旦開始，它們就會被藏起來。</p>
           </div>
           <div class="step">
             <div class="step__num">3</div>
-            <img class="step__img" src="/assets/img/game-play2.png" alt="探索中的遊戲畫面" loading="lazy" />
+            <img class="step__img" src="/assets/img/game-play2.png" alt="Explores 探索中的遊戲畫面｜定位街頭探索遊戲" loading="lazy" />
             <h3>憑記憶往前走</h3>
             <p>只靠剩餘時間與距離，朝目的地前進。「啊，就是那張照片裡的景色！」</p>
           </div>

--- a/zh/tester-android/index.html
+++ b/zh/tester-android/index.html
@@ -8,6 +8,22 @@
     <meta name="theme-color" content="#FACD00" />
     <meta name="robots" content="noindex" />
     <link rel="canonical" href="https://prokonjo.com/zh/tester-android/" />
+
+    <!-- Open Graph / Facebook -->
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Explores" />
+    <meta property="og:title" content="Explores Android 測試員招募（準備中）" />
+    <meta property="og:description" content="Explores 的 Android 測試員招募頁面。註冊 Google Groups → 安裝應用程式 → 啟動，共 3 個步驟。目前正在重新整理測試環境，暫停招募。" />
+    <meta property="og:url" content="https://prokonjo.com/zh/tester-android/" />
+    <meta property="og:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+    <meta property="og:locale" content="zh_TW" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Explores Android 測試員招募（準備中）" />
+    <meta name="twitter:description" content="Explores 的 Android 測試員招募頁面。註冊 Google Groups → 安裝應用程式 → 啟動，共 3 個步驟。目前正在重新整理測試環境，暫停招募。" />
+    <meta name="twitter:image" content="https://prokonjo.com/assets/img/ogp.jpg" />
+
     <link rel="icon" type="image/png" href="/assets/favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -64,7 +80,7 @@
 
     <section class="page-header">
       <div class="container">
-        <h1>Android 測試員（準備中）</h1>
+        <h1>Explores Android 測試員招募（準備中）</h1>
         <p class="page-header__lead">為了在 Google Play 正式上架，我們正在招募願意在 Android 上搶先體驗 Explores 的玩家。只要 3 個步驟即可完成參加！</p>
       </div>
     </section>


### PR DESCRIPTION
## 概要
SEO監査の **PR-B（構造化データ＋コンテンツ/ブランド）**。全7言語。PR #19（技術系・デプロイ済）に続く第2弾。**マージ＝本番反映は保留**（非JPはAI翻訳ドラフトのためネイティブ確認後にデプロイ推奨）。

## 変更（全7言語）
- **JSON-LD**: 最小の MobileApplication ブロックを統合 `@graph`（Organization + WebSite + MobileApplication〔screenshot/installUrl/award/inLanguage 追加〕+ **FAQPage**）に置換。FAQは各ページの既訳Q&Aをそのまま使用。**全7言語を json.loads で検証済（4ノード＋FAQ6件）**
- **ブランド統一**: JP可視テキストを「エクスプローラーズ」に統一（ストア合わせ）。「エクスプロラーズ」は JSON-LD `alternateName` ＋ フッター別名の2箇所のみ保持
- **JPキーワード**: 「位置情報ゲーム／散歩アプリ」を description＋本文に追加（従来0回）
- **非JP**: 位置情報/GPSのジャンル語を追加。en/fr/it/es の description を160字以内に短縮
- `og:locale:alternate`(6)・`og:image:alt`・`twitter:image:alt` を全indexに追加
- ヒーロー＋ステップ画像の alt にブランド/カテゴリ語を付与
- tester-android: OG/Twitterカード追加、H1を「ブランド＋募集＋（準備中）」に
- it: member alt の日本語混入をローマ字に修正

## 方針（据え置き）
- `operatingSystem` は iOS のみ（Android準備中。公開後に追加）
- `aggregateRating` は作らない（捏造禁止。App Store評価が出てから）

## ⚠️ デプロイ前レビュー必須
- **非日本語の文言はAIドラフト**。公開前にネイティブ確認推奨（リポジトリ規約）
- th の meta description が約184字とやや長め → ネイティブ確認時に短縮検討
- JSON-LD の `award` はイベント固有名のため全言語で日本語表記のまま（意図的）
- **es/it のメンバー表示名 `<h3>` が日本語のまま**（`alt` はローマ字化済）。en/fr/th はローマ字、zh は漢字。ローマ字表記の流儀（例: "Juyoung Chang" vs "Chang Ju-young"）も割れているため、ネイティブ確認時に統一を推奨

## 関連
- 監査: `.company/projects/explores/research/2026-06-02-lp-seo-audit.md`
- 別途: Google Search Console 認証＋sitemap送信、画像バイナリ最適化、Thai/繁中フォント読込（未対応）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
